### PR TITLE
manual cell classification (`signalSorter`) support for larger than RAM movie files

### DIFF
--- a/@calciumImagingAnalysis/calciumImagingAnalysis.m
+++ b/@calciumImagingAnalysis/calciumImagingAnalysis.m
@@ -187,7 +187,8 @@ classdef calciumImagingAnalysis < dynamicprops
 		validCNMFStructVarname = 'validCNMF';
 		structCNMRVarname = 'cnmfAnalysisOutput';
 		% PCAICA, EM, EXTRACT, CNMF, CNMFE
-		signalExtractionMethod = 'PCAICA';
+		% signalExtractionMethod = 'PCAICA';
+		signalExtractionMethod = 'EM';
 
 		settingOptions = struct(...
 			'analysisType',  {{'group','individual'}},...

--- a/@calciumImagingAnalysis/calciumImagingAnalysis.m
+++ b/@calciumImagingAnalysis/calciumImagingAnalysis.m
@@ -24,7 +24,7 @@ classdef calciumImagingAnalysis < dynamicprops
 		MICRON_PER_PIXEL =  2.51;
 
 		defaultObjDir = pwd;
-		classVersion = 'v3.20190124';
+		classVersion = 'v3.20190310';
 		serverPath = '';
 		privateSettingsPath = ['private' filesep 'settings' filesep 'privateLoadBatchFxns.m'];
 		% place where functions can temporarily story user settings

--- a/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
+++ b/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
@@ -140,8 +140,8 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 			case 'CNMF'
 				% options.CNMFE.originalCurrentSwitch
 				[success] = cnmfVersionDirLoad(options.CNMF.originalCurrentSwitch);
-
 				obj.signalExtractionMethod = signalExtractionMethod{signalExtractNo};
+				[gridWidth gridSpacing] = subfxnSignalSizeSpacing();
 				pcaicaPCsICsSwitchStr = subfxnNumExpectedSignals();
 				if options.CNMF.iterateOverParameterSpace==1
 					paramSetTmp = inputdlg({...
@@ -551,6 +551,7 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 							'CELLMax | movieImageCorrThreshold?',...
 							'CELLMax | loadPreviousChunks?',...
 							'CELLMax | saveIterMovie?',...
+							'CELLMax | sqOverlap?',...
 						},...
 						dlgStr,1,...
 						{...
@@ -575,6 +576,7 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 							'0.15',...
 							'0',...
 							'0',...
+							'16',...
 						}...
 					);setNo = 1;
 					options.CELLMax.readMovieChunks = str2num(movieSettings{setNo});setNo = setNo+1;
@@ -602,6 +604,8 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 
 					options.CELLMax.saveIterMovie = str2num(movieSettings{setNo});setNo = setNo+1;
 
+					options.CELLMax.sqOverlap = str2num(movieSettings{setNo});setNo = setNo+1;
+
 				case 'EXTRACT'
 					movieSettings = inputdlg({...
 							'EXTRACT | Use GPU (''gpu'') or CPU (''cpu'')?',...
@@ -625,7 +629,8 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 							'CNMF | iterate over parameter space? (1 = yes, 0 = no)',...
 							'CNMF | only run initialization algorithm? (1 = yes, 0 = no)',...
 							'CNMF | Spatial down-sampling factor (scalar >= 1)',...
-							'CNMF | Temporal down-sampling factor (scalar >= 1)'...
+							'CNMF | Temporal down-sampling factor (scalar >= 1)',...
+							'CNMF | Movie frame rate (scalar >= 1)'...
 						},...
 						dlgStr,1,...
 						{...
@@ -634,7 +639,8 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 							'0',...
 							'0',...
 							'1',...
-							'1'...
+							'1',...
+							num2str(obj.FRAMES_PER_SECOND)...
 						}...
 					);setNo = 1;
 					options.CNMF.originalCurrentSwitch = movieSettings{setNo};setNo = setNo+1;
@@ -643,6 +649,7 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 					options.CNMF.onlyRunInitialization = str2num(movieSettings{setNo});setNo = setNo+1;
 					options.CNMF.ssub = str2num(movieSettings{setNo});setNo = setNo+1;
 					options.CNMF.tsub = str2num(movieSettings{setNo});setNo = setNo+1;
+					options.CNMF.fr = str2num(movieSettings{setNo});setNo = setNo+1; obj.FRAMES_PER_SECOND = options.CNMF.fr;
 				case 'CNMFE'
 					movieSettings = inputdlg({...
 							'CNMF-E | Use CNMF-F ("cnmfe"), original ("original"), or most recent ("current") CNMF version?'...
@@ -801,7 +808,8 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 
 		% if cvx is not in the path, ask user
 		if isempty(which('cvx_begin'))
-			cvxSetupPathDefault = ['private' filesep 'cvx-w64' filesep 'cvx' filesep 'cvx_setup.m'];
+			% cvxSetupPathDefault = ['private' filesep 'cvx-w64' filesep 'cvx' filesep 'cvx_setup.m'];
+			cvxSetupPathDefault = ['signal_extraction' filesep 'cvx_rd' filesep 'cvx_setup.m'];
 			if exist(cvxSetupPathDefault,'file')==2
 				cvxSetupPath = cvxSetupPathDefault;
 			else
@@ -862,12 +870,16 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 		cnmfOptions.maxIter = 5;
 		% Expansion factor for HALS localized updates
 		cnmfOptions.bSiz = 3; %1e-5
+		% imaging frame rate in Hz (defaut: 30)
+		cnmfOptions.fr = options.CNMF.fr;
 
 		% Standard deviation of Gaussian kernel for initialization
-		cnmfOptions.otherCNMF.tau = 9;
+		% cnmfOptions.otherCNMF.tau = 9;
+		cnmfOptions.otherCNMF.tau = gridWidth.(obj.subjectStr{obj.fileNum})/2;
 		% cnmfOptions.otherCNMF.tau = [3 2 1; 3 2 1]';
 		% Order of autoregressive system (p = 0 no dynamics, p=1 just decay, p = 2, both rise and decay)
 		cnmfOptions.otherCNMF.p = 2;
+
 
 		if options.CNMF.onlyRunInitialization==1
 			% run only initialization algorithm
@@ -1012,10 +1024,24 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 		% 	run([folderPath filesep filePath]);
 		% end
 
+		% % if cvx is not in the path, ask user
+		% if isempty(which('cvx_begin'))
+		% 	[filePath,folderPath,~] = uigetfile(['*.*'],'select cvx_setup.m');
+		% 	run([folderPath filesep filePath]);
+		% end
+
 		% if cvx is not in the path, ask user
 		if isempty(which('cvx_begin'))
-			[filePath,folderPath,~] = uigetfile(['*.*'],'select cvx_setup.m');
-			run([folderPath filesep filePath]);
+			% cvxSetupPathDefault = ['private' filesep 'cvx-w64' filesep 'cvx' filesep 'cvx_setup.m'];
+			cvxSetupPathDefault = ['signal_extraction' filesep 'cvx_rd' filesep 'cvx_setup.m'];
+			if exist(cvxSetupPathDefault,'file')==2
+				cvxSetupPath = cvxSetupPathDefault;
+			else
+				[filePath,folderPath,~] = uigetfile(['*.*'],'select cvx_setup.m');
+				cvxSetupPath = [folderPath filesep filePath];
+			end
+			fprintf('cvx_setup.m at %s\n',cvxSetupPath);
+			run(cvxSetupPath);
 		end
 
 		% switch pcaicaPCsICsSwitchStr

--- a/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
+++ b/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
@@ -812,6 +812,7 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 			run(cvxSetupPath);
 		end
 
+		% Get the number of cells that should be requested
 		switch pcaicaPCsICsSwitchStr
 			case 'Subject'
 				nPCsnICs = obj.numExpectedSignals.(obj.signalExtractionMethod).(obj.subjectStr{obj.fileNum})
@@ -941,6 +942,7 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 				% [cnmfAnalysisOutput] = computeCnmfSignalExtraction(movieList,obj.numExpectedSignals.(obj.signalExtractionMethod).(obj.subjectStr{obj.fileNum}),'options',cnmfOptions);
 
 				numExpectedComponents = obj.numExpectedSignals.(obj.signalExtractionMethod).(obj.subjectStr{obj.fileNum});
+				numExpectedComponents = numExpectedComponents(1);
 				originalPath = [options.signalExtractionRootPath filesep 'cnmf_original'];
 				currentPath = [options.signalExtractionRootPath filesep 'cnmf_current'];
 				switch options.CNMF.originalCurrentSwitch

--- a/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
+++ b/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
@@ -1125,8 +1125,10 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 
 				movieList = getFileList(obj.inputFolders{validFoldersIdx(1)}, obj.fileFilterRegexp);
 				DFOFList.(thisSubjectStr) = loadMovieList(movieList,'convertToDouble',0,'frameList',[1:500],'inputDatasetName',obj.inputDatasetName,'treatMoviesAsContinuous',1);
-			catch
-
+			catch err
+				disp(repmat('@',1,7))
+				disp(getReport(err,'extended','hyperlinks','on'));
+				disp(repmat('@',1,7))
 			end
 		end
 		for thisSubjectStr=subjectList
@@ -1228,8 +1230,10 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 				% end
 				% close(h);
 				% clear DFOF;
-			catch
-
+			catch err
+				disp(repmat('@',1,7))
+				disp(getReport(err,'extended','hyperlinks','on'));
+				disp(repmat('@',1,7))
 			end
 		end
 		try

--- a/@calciumImagingAnalysis/modelGetSignalsImages.m
+++ b/@calciumImagingAnalysis/modelGetSignalsImages.m
@@ -236,8 +236,8 @@ function [inputSignals inputImages signalPeaks signalPeaksArray valid] = modelGe
 			% inputImages = double(permute(cnmfAnalysisOutput.extractedImages,[3 1 2]));
 			inputImages = double(cnmfAnalysisOutput.extractedImages);
 			% inputSignals = double(permute(extractAnalysisOutput.traces, [2 1]));
-			% inputSignals = double(cnmfAnalysisOutput.extractedSignals);
-			inputSignals = double(cnmfAnalysisOutput.extractedSignalsEst);
+			inputSignals = double(cnmfAnalysisOutput.extractedSignals);
+			% inputSignals = double(cnmfAnalysisOutput.extractedSignalsEst);
 
 			if options.loadAlgorithmPeaks==1
 				signalPeaks = cnmfAnalysisOutput.extractedPeaks>0;

--- a/@calciumImagingAnalysis/modelVarsFromFiles.m
+++ b/@calciumImagingAnalysis/modelVarsFromFiles.m
@@ -52,7 +52,8 @@ function obj = modelVarsFromFiles(obj)
 		reportMidpoint = str2num(usrInput{fieldnameNo+3});
 	else
 		% only update the threshold
-		numStdsForThresh = 3;
+		% numStdsForThresh = 3;
+		numStdsForThresh = 2.3;
 		reportMidpoint = 0;
 	end
 
@@ -233,8 +234,8 @@ function obj = modelVarsFromFiles(obj)
 					end
 					% signalImages = double(permute(cnmfAnalysisOutput.extractedImages,[3 1 2]));
 					signalImages = double(cnmfAnalysisOutput.extractedImages);
-					signalTraces = double(cnmfAnalysisOutput.extractedSignals);
-					% signalTraces = double(cnmfAnalysisOutput.extractedSignalsEst);
+					% signalTraces = double(cnmfAnalysisOutput.extractedSignals);
+					signalTraces = double(cnmfAnalysisOutput.extractedSignalsEst);
 					rawFiles = 1;
 				case 'CNMFE'
 					regexPairs = {...

--- a/@calciumImagingAnalysis/viewCreateObjmaps.m
+++ b/@calciumImagingAnalysis/viewCreateObjmaps.m
@@ -38,6 +38,8 @@ function obj = viewCreateObjmaps(obj,varargin)
 	options.dilateOutlinesFactor = 0;
 	% none or median
 	options.medianFilterImages = 'none'
+	% red, blue, gree
+	options.plotSignalsGraphColor = 'red';
 	% get options
 	options = getOptions(options,varargin);
 	% display(options)
@@ -66,7 +68,9 @@ function obj = viewCreateObjmaps(obj,varargin)
 				'Only show cellmap/trace graph? (1 = yes, 0 = no)',...
 				'Micron per pixel for scale bar',...
 				'Dilate outlines factor (integer)',...
-				'Filter images (none, median)'...
+				'Filter images (none, median)',...
+				'Activity traces color (red, green, blue)?',...
+				'Frames per second?'...
 			},...
 			'view movie settings',1,...
 			{...
@@ -82,7 +86,9 @@ function obj = viewCreateObjmaps(obj,varargin)
 				num2str(options.onlyShowMapTraceGraph),...
 				num2str(obj.MICRON_PER_PIXEL),...
 				num2str(options.dilateOutlinesFactor),...
-				'none'...
+				'none',...
+				options.plotSignalsGraphColor,...
+				num2str(obj.FRAMES_PER_SECOND)...
 			}...
 		);
 		obj.picsSavePath = movieSettings{1};
@@ -98,6 +104,8 @@ function obj = viewCreateObjmaps(obj,varargin)
 		obj.MICRON_PER_PIXEL = str2num(movieSettings{11});
 		options.dilateOutlinesFactor = str2num(movieSettings{12});
 		options.medianFilterImages = movieSettings{13};
+		options.plotSignalsGraphColor = movieSettings{14};
+		obj.FRAMES_PER_SECOND = str2num(movieSettings{15});
 		if length(cutLength)==1
 		else
 			options.signalCutIdx = cutLength;
@@ -376,6 +384,10 @@ function obj = viewCreateObjmaps(obj,varargin)
                     else
                     	[signalSnr sortedIdx] = sort(max(sortedinputSignals(:,options.signalCutIdx),[],2),'descend');
                     end
+
+                    % max(sortedinputSignals,[],2)
+                    % sortedIdx
+                    % pause
 					sortedinputSignals = inputSignalsTmp(sortedIdx,:);
 
 					% create overlap with new images
@@ -634,6 +646,7 @@ function obj = viewCreateObjmaps(obj,varargin)
 						hold on;
 
 					[signalSnr a] = computeSignalSnr(inputSignals,'testpeaks',signalPeaks,'testpeaksArray',signalPeakIdx);
+					signalSnr(isinf(signalSnr)) = 0;
 				[figHandle figNo] = openFigure(972, '');
 					clf
 					subplot(2,3,1);
@@ -958,15 +971,20 @@ function obj = viewCreateObjmaps(obj,varargin)
 
 	end
 	function plotTracesFigure()
+		% options
 		if size(sortedinputSignalsCut,1)==1
 			plot(sortedinputSignalsCut)
         else
-        	if sum(strcmp(obj.signalExtractionMethod,{'EM','CNMF','CNMFE'}))>0
-				plotSignalsGraph(sortedinputSignalsCut,'LineWidth',2.5,'incrementAmount',[],'newAxisColorOrder','red','smoothTrace',0,'maxIncrementPercent',0.4,'minAdd',0);
-        	else
-        		% plot(sortedinputSignalsCut)
-				plotSignalsGraph(sortedinputSignalsCut,'LineWidth',2.5,'incrementAmount',options.incrementAmount);
-        	end
+    %     	if sum(strcmp(obj.signalExtractionMethod,{'EM','CNMF','CNMFE'}))>0
+				% plotSignalsGraph(sortedinputSignalsCut,'LineWidth',2.5,'incrementAmount',[],'newAxisColorOrder',options.plotSignalsGraphColor,'smoothTrace',0,'maxIncrementPercent',0.4,'minAdd',0);
+    %     	else
+    %     		% plot(sortedinputSignalsCut)
+				% plotSignalsGraph(sortedinputSignalsCut,'LineWidth',2.5,'incrementAmount',options.incrementAmount,'newAxisColorOrder',options.plotSignalsGraphColor);
+    %     	end
+    	% figure;
+    	% imagesc(sortedinputSignalsCut);
+    	% pause
+    		plotSignalsGraph(sortedinputSignalsCut,'LineWidth',2.5,'incrementAmount',[],'newAxisColorOrder',options.plotSignalsGraphColor,'smoothTrace',0,'maxIncrementPercent',0.4,'minAdd',0);
 		end
 		nTicks = 10;
 		set(gca,'XTick',round(linspace(1,size(sortedinputSignalsCut,2),nTicks)))

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Note
 - Place in folder where MATLAB will have write permissions, as it also creates a `private` subdirectory to store some user information.
 - `file_exchange` folder contains File Exchange functions used by `calciumImagingAnalysis`. If does not exist, unzip `file_exchange.zip`.
 - In general, it is best to set the MATLAB startup directory to the `calciumImagingAnalysis` folder. This allows `java.opts` and `startup.m` to set the correct Java memory requirements and load the correct folders into the MATLAB path.
+- If it appears an old `calciumImagingAnalysis` respository is loaded after pulling a new version, run `restoredefaultpath` and check that old `calciumImagingAnalysis` folders are not in the MATLAB path.
 - This version of `calciumImagingAnalysis` has been tested on Windows MATLAB `2015b`, `2017a`, and `2018b`.
 
 ### Test data

--- a/classification/signalSorter.m
+++ b/classification/signalSorter.m
@@ -1492,8 +1492,13 @@ function [objCutMovie] = createObjCutMovieSignalSorter(options,testpeaks,thisTra
         objCutMovie = getObjCutMovie(tmpMovieHere,tmpImgHere,'createMontage',0,'extendedCrosshairs',2,'crossHairVal',maxValMovie*options.crossHairPercent,'outlines',1,'waitbarOn',0,'cropSize',cropSizeLength,'addPadding',usePadding,'xCoords',xCoords,'yCoords',yCoords,'outlineVal',NaN,'inputMovieDims',options.inputMovieDims,'hdf5Fid',options.hdf5Fid,'keepFileOpen',options.keepFileOpen);
     end
 
+    % Convert from cell to matrix
     objCutMovie = vertcat(objCutMovie{:});
     % objCutMovieTmp = objCutMovie{1};
+
+    % Insure that the peak images are the same class as the input images for calculation purposes
+    objCutMovie = cast(objCutMovie,class(tmpImgHere));
+
     dimSize = [size(objCutMovie,1) size(objCutMovie,2) length(timeVector)];
     diffDiffMatrix = NaN(dimSize);
     diffDiffMatrix2 = diffDiffMatrix;
@@ -1777,11 +1782,11 @@ function plotSignal(thisTrace,testpeaks,cellIDStr,instructionStr,minValTraces,ma
     % plot(thisTrace2, 'b');
 
     % plot(thisTrace, 'b');
-    plot(thisTrace, 'Color','k','LineWidth',3);
+    plot(thisTrace, 'Color','k','LineWidth',1);
     % plot(thisTrace, 'Color',[0.5 0.5 0.5],'LineWidth',3);
     hold on;
-    plot(inputSignalNoise,'Color',[127 127 255]/255);
-    plot(inputSignalSignal,'Color',[255 0 0]/255);
+    plot(inputSignalNoise,'Color',[127 127 255]/255,'LineWidth',0.5);
+    plot(inputSignalSignal,'Color',[255 0 0]/255,'LineWidth',0.5);
     % set(gca,'Color','k');
 
 
@@ -1793,7 +1798,14 @@ function plotSignal(thisTrace,testpeaks,cellIDStr,instructionStr,minValTraces,ma
     inputSignalSignal = inputSignalSignal+inputSignalNoise;
 
     % scatter(testpeaks, thisTrace(testpeaks), 'LineWidth',0.5,'MarkerFaceColor',[0 0 0], 'MarkerEdgeColor',[0 0 0])
-    scatter(testpeaks, thisTrace(testpeaks)*1.2, 30, '.', 'LineWidth',0.5,'MarkerFaceColor',[0 0 0], 'MarkerEdgeColor',[0 0 0])
+    scatter(testpeaks, min(maxValTraces*0.97,thisTrace(testpeaks)*1.4), 60, '.', 'LineWidth',0.5,'MarkerFaceColor',[0 0 0], 'MarkerEdgeColor',[0 0 0])
+    % scatter(testpeaks, maxValTraces*0.95*ones([length(testpeaks) 1]), 120, '.', 'LineWidth',0.5,'MarkerFaceColor',[0 0 0], 'MarkerEdgeColor',[0 0 0])
+
+    % for t = 1:length(testpeaks)
+    %     plot([testpeaks(t) testpeaks(t)],[thisTrace(testpeaks(t)) maxValTraces*0.95],'k-','LineWidth',0.5);
+    % end
+
+
     title([cellIDStr instructionStr])
     xlabel('frames');
     % ylabel('df/f');

--- a/classification/signalSorter.m
+++ b/classification/signalSorter.m
@@ -131,6 +131,7 @@ function [inputImages, inputSignals, choices] = signalSorter(inputImages,inputSi
     options.backgroundGood = [208,229,180]/255;
     options.backgroundBad = [244,166,166]/255;
     options.backgroundNeutral = repmat(230,[1 3])/255;
+    options.backgroundNegative = [166,166,244]/255;
     % type of colormap to use
     options.colormap = customColormap([]);
     % For the secondary zoomed cellmap, pixels to crop around
@@ -553,7 +554,8 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
     % subplotY = 2;
 
     if isempty(options.inputMovie)
-        objMapPlotLoc = [1 2 7 8];;
+        objMapPlotLoc = [7 8];;
+        objMapZoomPlotLoc = [1 2];
         tracePlotLoc = [9 10 11 12];
         avgSpikeTracePlot = [3 4];
     else
@@ -746,6 +748,8 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
             set(mainFig,'Color',options.backgroundGood);
         elseif valid(i)==0
             set(mainFig,'Color',options.backgroundBad);
+        elseif valid(i)==-1
+            set(mainFig,'Color',options.backgroundNegative);
         else
             set(mainFig,'Color',options.backgroundNeutral);
         end
@@ -833,8 +837,8 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
             % show the current image
             % subplot(subplotY,subplotX,filterPlotLoc)
             subplot(subplotY,subplotX,inputMoviePlotLoc2)
-                [thisImage] = subfxnCropImages(thisImage);
-                imagesc(thisImage);
+                [thisImageCrop] = subfxnCropImages(thisImage);
+                imagesc(thisImageCrop);
                 % colormap gray
                 axis off; % ij square
                 title(['signal ' cellIDStr 10 '(' num2str(sum(valid==1)) ' good)']);

--- a/downloadCnmfGithubRepositories.m
+++ b/downloadCnmfGithubRepositories.m
@@ -27,6 +27,10 @@ function [success] = downloadCnmfGithubRepositories(varargin)
 		for gitNo = 1:nRepos
 			display(repmat('=',1,7))
 			fprintf('%s\n',gitNameDisp{gitNo});
+			if exist([signalExtractionDir filesep outputDir{gitNo}],'dir')
+				fprintf('Already extracted %s\n',[signalExtractionDir filesep outputDir{gitNo}]);
+				continue;
+			end
 			% Make directory
 			rawSavePathDownload = [signalExtractionDir];
 			if ~exist(rawSavePathDownload,'dir');mkdir(rawSavePathDownload);fprintf('Made folder: %s',rawSavePathDownload);end

--- a/exampleFxn.m
+++ b/exampleFxn.m
@@ -28,9 +28,9 @@ function [output1,output2] = exampleFxn(input1,input2,varargin)
 	try
 		% Code
 	catch err
-		display(repmat('@',1,7))
+		disp(repmat('@',1,7))
 		disp(getReport(err,'extended','hyperlinks','on'));
-		display(repmat('@',1,7))
+		disp(repmat('@',1,7))
 	end
 end
 

--- a/file_exchange/natsortfiles/html/natsortfiles_doc.html
+++ b/file_exchange/natsortfiles/html/natsortfiles_doc.html
@@ -1,0 +1,294 @@
+
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+   <!--
+This HTML was auto-generated from MATLAB code.
+To make changes, update the MATLAB code and republish this document.
+      --><title>NATSORTFILES Examples</title><meta name="generator" content="MATLAB 7.11"><link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"><meta name="DC.date" content="2018-03-25"><meta name="DC.source" content="natsortfiles_doc.m"><style type="text/css">
+
+body {
+  background-color: white;
+  margin:10px;
+}
+
+h1 {
+  color: #990000; 
+  font-size: x-large;
+}
+
+h2 {
+  color: #990000;
+  font-size: medium;
+}
+
+/* Make the text shrink to fit narrow windows, but not stretch too far in 
+wide windows. */ 
+p,h1,h2,div.content div {
+  max-width: 600px;
+  /* Hack for IE6 */
+  width: auto !important; width: 600px;
+}
+
+pre.codeinput {
+  background: #EEEEEE;
+  padding: 10px;
+}
+@media print {
+  pre.codeinput {word-wrap:break-word; width:100%;}
+} 
+
+span.keyword {color: #0000FF}
+span.comment {color: #228B22}
+span.string {color: #A020F0}
+span.untermstring {color: #B20000}
+span.syscmd {color: #B28C00}
+
+pre.codeoutput {
+  color: #666666;
+  padding: 10px;
+}
+
+pre.error {
+  color: red;
+}
+
+p.footer {
+  text-align: right;
+  font-size: xx-small;
+  font-weight: lighter;
+  font-style: italic;
+  color: gray;
+}
+
+  </style></head><body><div class="content"><h1>NATSORTFILES Examples</h1><!--introduction--><p>The function <a href="https://www.mathworks.com/matlabcentral/fileexchange/47434"><tt>NATSORTFILES</tt></a> sorts a cell array of filenames or filepaths (1xN char), taking into account any number values within the strings. This is known as a <i>natural order sort</i> or an <i>alphanumeric sort</i>. Note that MATLAB's inbuilt <a href="http://www.mathworks.com/help/matlab/ref/sort.html"><tt>SORT</tt></a> function sorts the character codes only (as does <tt>SORT</tt> in most programming languages).</p><p><tt>NATSORTFILES</tt> is not a naive natural-order sort, but splits and sorts filenames and file extensions separately, which means that <tt>NATSORTFILES</tt> sorts shorter filenames before longer ones: this is known as a <i>dictionary sort</i>. For the same reason filepaths are split at every path-separator character (either <tt>'\'</tt> or <tt>'/'</tt>), and each directory level is sorted separately. See the "Explanation" sections below for more details.</p><p>For sorting the rows of a cell array of strings use <a href="https://www.mathworks.com/matlabcentral/fileexchange/47433"><tt>NATSORTROWS</tt></a>.</p><p>For sorting a cell array of strings use <a href="https://www.mathworks.com/matlabcentral/fileexchange/34464"><tt>NATSORT</tt></a>.</p><!--/introduction--><h2>Contents</h2><div><ul><li><a href="#1">Basic Usage</a></li><li><a href="#2">Output 2: Sort Index</a></li><li><a href="#3">Output 3: Debugging Array</a></li><li><a href="#4">Example with DIR and a Cell Array</a></li><li><a href="#5">Example with DIR and a Structure</a></li><li><a href="#6">Explanation: Dictionary Sort</a></li><li><a href="#7">Explanation: Filenames</a></li><li><a href="#8">Explanation: Filepaths</a></li><li><a href="#9">Regular Expression: Decimal Numbers, E-notation, +/- Sign</a></li><li><a href="#10">Regular Expression: Interactive Regular Expression Tool</a></li></ul></div><h2>Basic Usage<a name="1"></a></h2><p>By default <tt>NATSORTFILES</tt> interprets consecutive digits as being part of a single integer, each number is considered to be as wide as one letter:</p><pre class="codeinput">A = {<span class="string">'a2.txt'</span>, <span class="string">'a10.txt'</span>, <span class="string">'a1.txt'</span>};
+sort(A)
+natsortfiles(A)
+</pre><pre class="codeoutput">ans = 
+    'a1.txt'    'a10.txt'    'a2.txt'
+ans = 
+    'a1.txt'    'a2.txt'    'a10.txt'
+</pre><h2>Output 2: Sort Index<a name="2"></a></h2><p>The second output argument is a numeric array of the sort indices <tt>ndx</tt>, such that <tt>Y = X(ndx)</tt> where <tt>Y = natsortfiles(X)</tt>:</p><pre class="codeinput">[~,ndx] = natsortfiles(A)
+</pre><pre class="codeoutput">ndx =
+     3     1     2
+</pre><h2>Output 3: Debugging Array<a name="3"></a></h2><p>The third output is a cell vector of cell arrays, where each cell array contains individual characters and numbers (after converting to numeric). This is useful for confirming that the numbers are being correctly identified by the regular expression. The cells of the cell vector correspond to the split directories, filenames, and file extensions. Note that the rows of the debugging cell arrays are <a href="https://www.mathworks.com/company/newsletters/articles/matrix-indexing-in-matlab.html">linearly indexed</a> from the input cell array.</p><pre class="codeinput">[~,~,dbg] = natsortfiles(A);
+dbg{:}
+</pre><pre class="codeoutput">ans = 
+    'a'    [ 2]
+    'a'    [10]
+    'a'    [ 1]
+ans = 
+    '.'    't'    'x'    't'
+    '.'    't'    'x'    't'
+    '.'    't'    'x'    't'
+</pre><h2>Example with DIR and a Cell Array<a name="4"></a></h2><p>One common situation is to use <a href="https://www.mathworks.com/help/matlab/ref/dir.html"><tt>DIR</tt></a> to identify files in a folder, sort them into the correct order, and then loop over them: below is an example of how to do this. Remember to <a href="https://www.mathworks.com/help/matlab/matlab_prog/preallocating-arrays.html">preallocate</a> all output arrays before the loop!</p><pre class="codeinput">D = <span class="string">'natsortfiles_test'</span>; <span class="comment">% directory path</span>
+S = dir(fullfile(D,<span class="string">'*.txt'</span>)); <span class="comment">% get list of files in directory</span>
+N = natsortfiles({S.name}); <span class="comment">% sort file names into order</span>
+<span class="keyword">for</span> k = 1:numel(N)
+	disp(fullfile(D,N{k}))
+<span class="keyword">end</span>
+</pre><pre class="codeoutput">natsortfiles_test\A_1.txt
+natsortfiles_test\A_1-new.txt
+natsortfiles_test\A_1_new.txt
+natsortfiles_test\A_2.txt
+natsortfiles_test\A_3.txt
+natsortfiles_test\A_10.txt
+natsortfiles_test\A_100.txt
+natsortfiles_test\A_200.txt
+</pre><h2>Example with DIR and a Structure<a name="5"></a></h2><p>Users who need to access the <tt>DIR</tt> structure fields can use <tt>NATSORTFILE</tt>'s second output to sort <tt>DIR</tt>'s output structure into the correct order:</p><pre class="codeinput">D = <span class="string">'natsortfiles_test'</span>; <span class="comment">% directory path</span>
+S = dir(fullfile(D,<span class="string">'*.txt'</span>)); <span class="comment">% get list of files in directory</span>
+[~,ndx] = natsortfiles({S.name}); <span class="comment">% indices of correct order</span>
+S = S(ndx); <span class="comment">% sort structure using indices</span>
+<span class="keyword">for</span> k = 1:numel(S)
+	fprintf(<span class="string">'%-13s%s\n'</span>,S(k).name,S(k).date)
+<span class="keyword">end</span>
+</pre><pre class="codeoutput">A_1.txt      22-Jul-2017 09:13:23
+A_1-new.txt  22-Jul-2017 09:13:23
+A_1_new.txt  22-Jul-2017 09:13:23
+A_2.txt      22-Jul-2017 09:13:23
+A_3.txt      22-Jul-2017 09:13:23
+A_10.txt     22-Jul-2017 09:13:23
+A_100.txt    22-Jul-2017 09:13:23
+A_200.txt    22-Jul-2017 09:13:23
+</pre><h2>Explanation: Dictionary Sort<a name="6"></a></h2><p>Filenames and file extensions are separated by the extension separator: the period character <tt>'.'</tt>. Using a normal <tt>SORT</tt> the period gets sorted <i>after</i> all of the characters from 0 to 45 (including <tt>!"#$%&amp;'()*+,-</tt>, the space character, and all of the control characters, e.g. newlines, tabs, etc). This means that a naive <tt>SORT</tt> or natural-order sort will sort some short filenames after longer filenames. In order to provide the correct dictionary sort, with shorter filenames first, <tt>NATSORTFILES</tt> splits and sorts filenames and file extensions separately:</p><pre class="codeinput">B = {<span class="string">'test_ccc.m'</span>; <span class="string">'test-aaa.m'</span>; <span class="string">'test.m'</span>; <span class="string">'test.bbb.m'</span>};
+sort(B) <span class="comment">% '-' sorts before '.'</span>
+natsort(B) <span class="comment">% '-' sorts before '.'</span>
+natsortfiles(B) <span class="comment">% correct dictionary sort</span>
+</pre><pre class="codeoutput">ans = 
+    'test-aaa.m'
+    'test.bbb.m'
+    'test.m'
+    'test_ccc.m'
+ans = 
+    'test-aaa.m'
+    'test.bbb.m'
+    'test.m'
+    'test_ccc.m'
+ans = 
+    'test.m'
+    'test-aaa.m'
+    'test.bbb.m'
+    'test_ccc.m'
+</pre><h2>Explanation: Filenames<a name="7"></a></h2><p><tt>NATSORTFILES</tt> combines a dictionary sort with a natural-order sort, so that the number values within the filenames are taken into consideration:</p><pre class="codeinput">C = {<span class="string">'test2.m'</span>; <span class="string">'test10-old.m'</span>; <span class="string">'test.m'</span>; <span class="string">'test10.m'</span>; <span class="string">'test1.m'</span>};
+sort(C) <span class="comment">% Wrong numeric order.</span>
+natsort(C) <span class="comment">% Correct numeric order, but longer before shorter.</span>
+natsortfiles(C) <span class="comment">% Correct numeric order and dictionary sort.</span>
+</pre><pre class="codeoutput">ans = 
+    'test.m'
+    'test1.m'
+    'test10-old.m'
+    'test10.m'
+    'test2.m'
+ans = 
+    'test.m'
+    'test1.m'
+    'test2.m'
+    'test10-old.m'
+    'test10.m'
+ans = 
+    'test.m'
+    'test1.m'
+    'test2.m'
+    'test10.m'
+    'test10-old.m'
+</pre><h2>Explanation: Filepaths<a name="8"></a></h2><p>For the same reason, filepaths are split at each file path separator character (both <tt>'/'</tt> and <tt>'\'</tt> are considered to be file path separators) and every level of directory names are sorted separately. This ensures that the directory names are sorted with a dictionary sort and that any numbers are taken into consideration:</p><pre class="codeinput">D = {<span class="string">'A2-old\test.m'</span>;<span class="string">'A10\test.m'</span>;<span class="string">'A2\test.m'</span>;<span class="string">'AXarchive.zip'</span>;<span class="string">'A1\test.m'</span>};
+sort(D) <span class="comment">% Wrong numeric order, and '-' sorts before '\':</span>
+natsort(D) <span class="comment">% correct numeric order, but longer before shorter.</span>
+natsortfiles(D) <span class="comment">% correct numeric order and dictionary sort.</span>
+</pre><pre class="codeoutput">ans = 
+    'A10\test.m'
+    'A1\test.m'
+    'A2-old\test.m'
+    'A2\test.m'
+    'AXarchive.zip'
+ans = 
+    'A1\test.m'
+    'A2-old\test.m'
+    'A2\test.m'
+    'A10\test.m'
+    'AXarchive.zip'
+ans = 
+    'AXarchive.zip'
+    'A1\test.m'
+    'A2\test.m'
+    'A2-old\test.m'
+    'A10\test.m'
+</pre><h2>Regular Expression: Decimal Numbers, E-notation, +/- Sign<a name="9"></a></h2><p><tt>NATSORTFILES</tt> is a wrapper for <tt>NATSORT</tt>, which means all of <tt>NATSORT</tt>'s options are also supported. In particular the number recognition can be customized to detect numbers with decimal digits, E-notation, a +/- sign, or other specific features. This detection is defined by providing an appropriate regular expression: see <tt>NATSORT</tt> for details and examples.</p><pre class="codeinput">E = {<span class="string">'test24.csv'</span>,<span class="string">'test1.8.csv'</span>,<span class="string">'test5.csv'</span>,<span class="string">'test3.3.csv'</span>,<span class="string">'test12.csv'</span>};
+natsortfiles(E,<span class="string">'\d+\.?\d*'</span>)
+</pre><pre class="codeoutput">ans = 
+    'test1.8.csv'    'test3.3.csv'    'test5.csv'    'test12.csv'    'test24.csv'
+</pre><h2>Regular Expression: Interactive Regular Expression Tool<a name="10"></a></h2><p>Regular expressions are powerful and compact, but getting them right is not always easy. One assistance is to download my interactive tool <a href="https://www.mathworks.com/matlabcentral/fileexchange/48930"><tt>IREGEXP</tt></a>, which lets you quickly try different regular expressions and see all of <a href="https://www.mathworks.com/help/matlab/ref/regexp.html"><tt>REGEXP</tt></a>'s outputs displayed and updated as you type.</p><p class="footer"><br>
+      Published with MATLAB&reg; 7.11<br></p></div><!--
+##### SOURCE BEGIN #####
+%% NATSORTFILES Examples
+% The function <https://www.mathworks.com/matlabcentral/fileexchange/47434
+% |NATSORTFILES|> sorts a cell array of filenames or filepaths (1xN char),
+% taking into account any number values within the strings. This is known
+% as a _natural order sort_ or an _alphanumeric sort_. Note that MATLAB's
+% inbuilt <http://www.mathworks.com/help/matlab/ref/sort.html |SORT|> function
+% sorts the character codes only (as does |SORT| in most programming languages).
+%
+% |NATSORTFILES| is not a naive natural-order sort, but splits and sorts
+% filenames and file extensions separately, which means that |NATSORTFILES|
+% sorts shorter filenames before longer ones: this is known as a _dictionary
+% sort_. For the same reason filepaths are split at every path-separator
+% character (either |'\'| or |'/'|), and each directory level is sorted
+% separately. See the "Explanation" sections below for more details.
+%
+% For sorting the rows of a cell array of strings use
+% <https://www.mathworks.com/matlabcentral/fileexchange/47433 |NATSORTROWS|>.
+%
+% For sorting a cell array of strings use
+% <https://www.mathworks.com/matlabcentral/fileexchange/34464 |NATSORT|>.
+%
+%% Basic Usage
+% By default |NATSORTFILES| interprets consecutive digits as being part of
+% a single integer, each number is considered to be as wide as one letter:
+A = {'a2.txt', 'a10.txt', 'a1.txt'};
+sort(A)
+natsortfiles(A)
+%% Output 2: Sort Index
+% The second output argument is a numeric array of the sort indices |ndx|,
+% such that |Y = X(ndx)| where |Y = natsortfiles(X)|:
+[~,ndx] = natsortfiles(A)
+%% Output 3: Debugging Array
+% The third output is a cell vector of cell arrays, where each cell array
+% contains individual characters and numbers (after converting to numeric).
+% This is useful for confirming that the numbers are being correctly
+% identified by the regular expression. The cells of the cell vector
+% correspond to the split directories, filenames, and file extensions. 
+% Note that the rows of the debugging cell arrays are
+% <https://www.mathworks.com/company/newsletters/articles/matrix-indexing-in-matlab.html
+% linearly indexed> from the input cell array.
+[~,~,dbg] = natsortfiles(A);
+dbg{:}
+%% Example with DIR and a Cell Array
+% One common situation is to use <https://www.mathworks.com/help/matlab/ref/dir.html
+% |DIR|> to identify files in a folder, sort them into the correct order,
+% and then loop over them: below is an example of how to do this.
+% Remember to <https://www.mathworks.com/help/matlab/matlab_prog/preallocating-arrays.html
+% preallocate> all output arrays before the loop!
+D = 'natsortfiles_test'; % directory path
+S = dir(fullfile(D,'*.txt')); % get list of files in directory
+N = natsortfiles({S.name}); % sort file names into order
+for k = 1:numel(N)
+	disp(fullfile(D,N{k}))
+end
+%% Example with DIR and a Structure
+% Users who need to access the |DIR| structure fields can use |NATSORTFILE|'s
+% second output to sort |DIR|'s output structure into the correct order:
+D = 'natsortfiles_test'; % directory path
+S = dir(fullfile(D,'*.txt')); % get list of files in directory
+[~,ndx] = natsortfiles({S.name}); % indices of correct order
+S = S(ndx); % sort structure using indices
+for k = 1:numel(S)
+	fprintf('%-13s%s\n',S(k).name,S(k).date)
+end
+%% Explanation: Dictionary Sort
+% Filenames and file extensions are separated by the extension separator:
+% the period character |'.'|. Using a normal |SORT| the period gets sorted
+% _after_ all of the characters from 0 to 45 (including |!"#$%&'()*+,-|,
+% the space character, and all of the control characters, e.g. newlines,
+% tabs, etc). This means that a naive |SORT| or natural-order sort will
+% sort some short filenames after longer filenames. In order to provide
+% the correct dictionary sort, with shorter filenames first, |NATSORTFILES|
+% splits and sorts filenames and file extensions separately:
+B = {'test_ccc.m'; 'test-aaa.m'; 'test.m'; 'test.bbb.m'};
+sort(B) % '-' sorts before '.'
+natsort(B) % '-' sorts before '.'
+natsortfiles(B) % correct dictionary sort
+%% Explanation: Filenames
+% |NATSORTFILES| combines a dictionary sort with a natural-order sort, so
+% that the number values within the filenames are taken into consideration:
+C = {'test2.m'; 'test10-old.m'; 'test.m'; 'test10.m'; 'test1.m'};
+sort(C) % Wrong numeric order.
+natsort(C) % Correct numeric order, but longer before shorter.
+natsortfiles(C) % Correct numeric order and dictionary sort.
+%% Explanation: Filepaths
+% For the same reason, filepaths are split at each file path separator
+% character (both |'/'| and |'\'| are considered to be file path separators)
+% and every level of directory names are sorted separately. This ensures
+% that the directory names are sorted with a dictionary sort and that any
+% numbers are taken into consideration:
+D = {'A2-old\test.m';'A10\test.m';'A2\test.m';'AXarchive.zip';'A1\test.m'};
+sort(D) % Wrong numeric order, and '-' sorts before '\':
+natsort(D) % correct numeric order, but longer before shorter.
+natsortfiles(D) % correct numeric order and dictionary sort.
+%% Regular Expression: Decimal Numbers, E-notation, +/- Sign
+% |NATSORTFILES| is a wrapper for |NATSORT|, which means all of |NATSORT|'s
+% options are also supported. In particular the number recognition can be
+% customized to detect numbers with decimal digits, E-notation, a +/- sign,
+% or other specific features. This detection is defined by providing an
+% appropriate regular expression: see |NATSORT| for details and examples.
+E = {'test24.csv','test1.8.csv','test5.csv','test3.3.csv','test12.csv'};
+natsortfiles(E,'\d+\.?\d*')
+%% Regular Expression: Interactive Regular Expression Tool
+% Regular expressions are powerful and compact, but getting them right is
+% not always easy. One assistance is to download my interactive tool
+% <https://www.mathworks.com/matlabcentral/fileexchange/48930 |IREGEXP|>,
+% which lets you quickly try different regular expressions and see all of
+% <https://www.mathworks.com/help/matlab/ref/regexp.html |REGEXP|>'s
+% outputs displayed and updated as you type.
+##### SOURCE END #####
+--></body></html>

--- a/file_exchange/natsortfiles/license.txt
+++ b/file_exchange/natsortfiles/license.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2018, Stephen Cobeldick
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/file_exchange/natsortfiles/natsort.m
+++ b/file_exchange/natsortfiles/natsort.m
@@ -1,0 +1,330 @@
+function [X,ndx,dbg] = natsort(X,xpr,varargin) %#ok<*SPERR>
+% Alphanumeric / Natural-Order sort the strings in a cell array of strings (1xN char).
+%
+% (c) 2012 Stephen Cobeldick
+%
+% Alphanumeric sort of a cell array of strings: sorts by character order
+% and also by the values of any numbers that are within the strings. The
+% default is case-insensitive ascending with integer number substrings:
+% optional inputs control the sort direction, case sensitivity, and number
+% matching (see the section "Number Substrings" below).
+%
+%%% Example:
+% X = {'x2', 'x10', 'x1'};
+% sort(X)
+%  ans =  'x1'  'x10'  'x2'
+% natsort(X)
+%  ans =  'x1'  'x2'  'x10'
+%
+%%% Syntax:
+%  Y = natsort(X)
+%  Y = natsort(X,xpr)
+%  Y = natsort(X,xpr,<options>)
+% [Y,ndx] = natsort(X,...)
+% [Y,ndx,dbg] = natsort(X,...)
+%
+% To sort filenames or filepaths use NATSORTFILES (File Exchange 47434).
+% To sort the rows of a cell array of strings use NATSORTROWS (File Exchange 47433).
+%
+% See also NATSORTFILES NATSORTROWS SORT CELLSTR IREGEXP REGEXP SSCANF INTMAX
+%
+%% Number Substrings %%
+%
+% By default consecutive digit characters are interpreted as an integer.
+% The optional regular expression pattern <xpr> permits the numbers to also
+% include a +/- sign, decimal digits, exponent E-notation, or any literal
+% characters, quantifiers, or look-around requirements. For more information:
+% http://www.mathworks.com/help/matlab/matlab_prog/regular-expressions.html
+%
+% The substrings are then parsed by SSCANF into numeric variables, using
+% either the *default format '%f' or the user-supplied format specifier.
+%
+% This table shows some example regular expression patterns for some common
+% notations and ways of writing numbers (see section "Examples" for more):
+%
+% <xpr> Regular | Number Substring | Number Substring              | SSCANF
+% Expression:   | Match Examples:  | Match Description:            | Format Specifier:
+% ==============|==================|===============================|==================
+% *         \d+ | 0, 1, 234, 56789 | unsigned integer              | %f  %u  %lu  %i
+% --------------|------------------|-------------------------------|------------------
+%     (-|+)?\d+ | -1, 23, +45, 678 | integer with optional +/- sign| %f  %d  %ld  %i
+% --------------|------------------|-------------------------------|------------------
+%     \d+\.?\d* | 012, 3.45, 678.9 | integer or decimal            | %f
+% --------------|------------------|-------------------------------|------------------
+%   \d+|Inf|NaN | 123, 4, Inf, NaN | integer, infinite or NaN value| %f
+% --------------|------------------|-------------------------------|------------------
+%  \d+\.\d+e\d+ | 0.123e4, 5.67e08 | exponential notation          | %f
+% --------------|------------------|-------------------------------|------------------
+%  0[0-7]+      | 012, 03456, 0700 | octal prefix & notation       | %o  %i
+% --------------|------------------|-------------------------------|------------------
+%  0X[0-9A-F]+  | 0X0, 0XFF, 0X7C4 | hexadecimal prefix & notation | %x  %i
+% --------------|------------------|-------------------------------|------------------
+%  0B[01]+      | 0B101, 0B0010111 | binary prefix & notation      | %b   (not SSCANF)
+% --------------|------------------|-------------------------------|------------------
+%
+% The SSCANF format specifier (including %b) can include literal characters
+% and skipped fields. The octal, hexadecimal and binary prefixes are optional.
+% For more information: http://www.mathworks.com/help/matlab/ref/sscanf.html
+%
+%% Debugging Output Array %%
+%
+% The third output is a cell array <dbg>, to check if the numbers have
+% been matched by the regular expression <rgx> and converted to numeric
+% by the SSCANF format. The rows of <dbg> are linearly indexed from <X>:
+%
+% [~,~,dbg] = natsort(X)
+% dbg = 
+%    'x'    [ 2]
+%    'x'    [10]
+%    'x'    [ 1]
+%
+%% Relative Sort Order %%
+%
+% The sort order of the number substrings relative to the characters
+% can be controlled by providing one of the following string options:
+%
+% Option Token:| Relative Sort Order:                 | Example:
+% =============|======================================|====================
+% 'beforechar' | numbers < char(0:end)                | '1' < '#' < 'A'
+% -------------|--------------------------------------|--------------------
+% 'afterchar'  | char(0:end) < numbers                | '#' < 'A' < '1'
+% -------------|--------------------------------------|--------------------
+% 'asdigit'   *| char(0:47) < numbers < char(48:end)  | '#' < '1' < 'A'
+% -------------|--------------------------------------|--------------------
+%
+% Note that the digit characters have character values 48 to 57, inclusive.
+%
+%% Examples %%
+%
+%%% Multiple integer substrings (e.g. release version numbers):
+% B = {'v10.6', 'v9.10', 'v9.5', 'v10.10', 'v9.10.20', 'v9.10.8'};
+% sort(B)
+%  ans =  'v10.10'  'v10.6'  'v9.10'  'v9.10.20'  'v9.10.8'  'v9.5'
+% natsort(B)
+%  ans =  'v9.5'  'v9.10'  'v9.10.8'  'v9.10.20'  'v10.6'  'v10.10'
+%
+%%% Integer, decimal or Inf number substrings, possibly with +/- signs:
+% C = {'test+Inf', 'test11.5', 'test-1.4', 'test', 'test-Inf', 'test+0.3'};
+% sort(C)
+%  ans =  'test'  'test+0.3'  'test+Inf'  'test-1.4'  'test-Inf'  'test11.5'
+% natsort(C, '(-|+)?(Inf|\d+\.?\d*)')
+%  ans =  'test'  'test-Inf'  'test-1.4'  'test+0.3'  'test11.5'  'test+Inf'
+%
+%%% Integer or decimal number substrings, possibly with an exponent:
+% D = {'0.56e007', '', '4.3E-2', '10000', '9.8'};
+% sort(D)
+%  ans =  ''  '0.56e007'  '10000'  '4.3E-2'  '9.8'
+% natsort(D, '\d+\.?\d*(E(+|-)?\d+)?')
+%  ans =  ''  '4.3E-2'  '9.8'  '10000'  '0.56e007'
+%
+%%% Hexadecimal number substrings (possibly with '0X' prefix):
+% E = {'a0X7C4z', 'a0X5z', 'a0X18z', 'aFz'};
+% sort(E)
+%  ans =  'a0X18z'  'a0X5z'  'a0X7C4z'  'aFz'
+% natsort(E, '(?<=a)(0X)?[0-9A-F]+', '%x')
+%  ans =  'a0X5z'  'aFz'  'a0X18z'  'a0X7C4z'
+%
+%%% Binary number substrings (possibly with '0B' prefix):
+% F = {'a11111000100z', 'a0B101z', 'a0B000000000011000z', 'a1111z'};
+% sort(F)
+%  ans =  'a0B000000000011000z'  'a0B101z'  'a11111000100z'  'a1111z'
+% natsort(F, '(0B)?[01]+', '%b')
+%  ans =  'a0B101z'  'a1111z'  'a0B000000000011000z'  'a11111000100z'
+%
+%%% UINT64 number substrings (with full precision!):
+% natsort({'a18446744073709551615z', 'a18446744073709551614z'}, [], '%lu')
+%  ans =   'a18446744073709551614z'  'a18446744073709551615z'
+%
+%%% Case sensitivity:
+% G = {'a2', 'A20', 'A1', 'a10', 'A2', 'a1'};
+% natsort(G, [], 'ignorecase') % default
+%  ans =   'A1'  'a1'  'a2'  'A2'  'a10'  'A20'
+% natsort(G, [], 'matchcase')
+%  ans =   'A1'  'A2'  'A20'  'a1'  'a2'  'a10'
+%
+%%% Sort direction:
+% H = {'2', 'a', '3', 'B', '1'};
+% natsort(H, [], 'ascend') % default
+%  ans =   '1'  '2'  '3'  'a'  'B'
+% natsort(H, [], 'descend')
+%  ans =   'B'  'a'  '3'  '2'  '1'
+%
+%%% Relative sort-order of number substrings compared to characters:
+% V = num2cell(char(32+randperm(63)));
+% cell2mat(natsort(V, [], 'asdigit')) % default
+%  ans = '!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_'
+% cell2mat(natsort(V, [], 'beforechar'))
+%  ans = '0123456789!"#$%&'()*+,-./:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_'
+% cell2mat(natsort(V, [], 'afterchar'))
+%  ans = '!"#$%&'()*+,-./:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_0123456789'
+%
+%% Input and Output Arguments %%
+%
+%%% Inputs (*=default):
+%   X   = CellArrayOfCharRowVectors, to be sorted into natural-order.
+%   xpr = CharRowVector, regular expression for number substrings, '\d+'*.
+% <options> tokens can be entered in any order, as many as required:
+%   - Sort direction: 'descend'/'ascend'*.
+%   - Case sensitive/insensitive matching: 'matchcase'/'ignorecase'*.
+%   - Relative sort of numbers: 'beforechar'/'afterchar'/'asdigit'*.
+%   - The SSCANF number conversion format, e.g.: '%x', '%i', '%f'*, etc.
+%
+%%% Outputs:
+%   Y   = CellArrayOfCharRowVectors, <X> sorted into natural-order.
+%   ndx = NumericArray, such that Y = X(ndx). The same size as <X>.
+%   dbg = CellArray of the parsed characters and number values. Each row is
+%         one input char vector, linear-indexed from <X>. To help debug <xpr>.
+%
+% [X,ndx,dbg] = natsort(X,xpr*,<options>)
+
+%% Input Wrangling %%
+%
+assert(iscell(X),'First input <X> must be a cell array.')
+tmp = cellfun('isclass',X,'char') & cellfun('size',X,1)<2 & cellfun('ndims',X)<3;
+assert(all(tmp(:)),'First input <X> must be a cell array of char row vectors (1xN char).')
+%
+% Regular expression:
+if nargin<2 || isnumeric(xpr)&&isempty(xpr)
+	xpr = '\d+';
+else
+	assert(ischar(xpr)&&isrow(xpr),'Second input <xpr> must be a regular expression (char row vector).')
+end
+%
+% Optional arguments:
+tmp = cellfun('isclass',varargin,'char') & 1==cellfun('size',varargin,1) & 2==cellfun('ndims',varargin);
+assert(all(tmp(:)),'All optional arguments must be char row vectors (1xN char).')
+% Character case matching:
+ChrM = strcmpi(varargin,'matchcase');
+ChrX = strcmpi(varargin,'ignorecase')|ChrM;
+% Sort direction:
+DrnD = strcmpi(varargin,'descend');
+DrnX = strcmpi(varargin,'ascend')|DrnD;
+% Relative sort-order of numbers compared to characters:
+RsoB = strcmpi(varargin,'beforechar');
+RsoA = strcmpi(varargin,'afterchar');
+RsoX = strcmpi(varargin,'asdigit')|RsoB|RsoA;
+% SSCANF conversion format:
+FmtX = ~(ChrX|DrnX|RsoX);
+%
+if nnz(FmtX)>1
+	tmp = sprintf(', ''%s''',varargin{FmtX});
+	error('Overspecified optional arguments:%s.',tmp(2:end))
+end
+if nnz(DrnX)>1
+	tmp = sprintf(', ''%s''',varargin{DrnX});
+	error('Sort direction is overspecified:%s.',tmp(2:end))
+end
+if nnz(RsoX)>1
+	tmp = sprintf(', ''%s''',varargin{RsoX});
+	error('Relative sort-order is overspecified:%s.',tmp(2:end))
+end
+%
+%% Split Strings %%
+%
+% Split strings into number and remaining substrings:
+[MtS,MtE,MtC,SpC] = regexpi(X(:),xpr,'start','end','match','split',varargin{ChrX});
+%
+% Determine lengths:
+MtcD = cellfun(@minus,MtE,MtS,'UniformOutput',false);
+LenZ = cellfun('length',X(:))-cellfun(@sum,MtcD);
+LenY = max(LenZ);
+LenX = numel(MtC);
+%
+dbg = cell(LenX,LenY);
+NuI = false(LenX,LenY);
+ChI = false(LenX,LenY);
+ChA = char(double(ChI));
+%
+ndx = 1:LenX;
+for k = ndx(LenZ>0)
+	% Determine indices of numbers and characters:
+	ChI(k,1:LenZ(k)) = true;
+	if ~isempty(MtS{k})
+		tmp = MtE{k} - cumsum(MtcD{k});
+		dbg(k,tmp) = MtC{k};
+		NuI(k,tmp) = true;
+		ChI(k,tmp) = false;
+	end
+	% Transfer characters into char array:
+	if any(ChI(k,:))
+		tmp = SpC{k};
+		ChA(k,ChI(k,:)) = [tmp{:}];
+	end
+end
+%
+%% Convert Number Substrings %%
+%
+if nnz(FmtX) % One format specifier
+	fmt = varargin{FmtX};
+	err = ['The supplied format results in an empty output from sscanf: ''',fmt,''''];
+	pct = '(?<!%)(%%)*%'; % match an odd number of % characters.
+	[T,S] = regexp(fmt,[pct,'(\d*)([bdiuoxfeg]|l[diuox])'],'tokens','split');
+	assert(isscalar(T),'Unsupported optional argument: ''%s''',fmt)
+	assert(isempty(T{1}{2}),'Format specifier cannot include field-width: ''%s''',fmt)
+	switch T{1}{3}(1)
+		case 'b' % binary
+			fmt = regexprep(fmt,[pct,'(\*?)b'],'$1%$2[01]');
+			val = dbg(NuI);
+			if numel(S{1})<2 || ~strcmpi('0B',S{1}(end-1:end))
+				% Remove '0B' if not specified in the format string:
+				val = regexprep(val,'(0B)?([01]+)','$2','ignorecase');
+			end
+			val = cellfun(@(s)sscanf(s,fmt),val, 'UniformOutput',false);
+			assert(~any(cellfun('isempty',val)),err)
+			NuA(NuI) = cellfun(@(s)sum(pow2(s-'0',numel(s)-1:-1:0)),val);
+		case 'l' % 64-bit
+			NuA(NuI) = cellfun(@(s)sscanf(s,fmt),dbg(NuI)); %slow!
+		otherwise % double
+			NuA(NuI) = sscanf(sprintf('%s\v',dbg{NuI}),[fmt,'\v']); % fast!
+	end
+else % No format specifier -> double
+	NuA(NuI) = sscanf(sprintf('%s\v',dbg{NuI}),'%f\v');
+end
+% Note: NuA's class is determined by SSCANF or the custom binary parser.
+NuA(~NuI) = 0;
+NuA = reshape(NuA,LenX,LenY);
+%
+%% Debugging Array %%
+%
+if nargout>2
+	dbg(:) = {''};
+	for k = reshape(find(NuI),1,[])
+		dbg{k} = NuA(k);
+	end
+	for k = reshape(find(ChI),1,[])
+		dbg{k} = ChA(k);
+	end
+end
+%
+%% Sort Columns %%
+%
+if ~any(ChrM) % ignorecase
+	ChA = upper(ChA);
+end
+%
+ide = ndx.';
+% From the last column to the first...
+for n = LenY:-1:1
+	% ...sort the characters and number values:
+	[C,idc] = sort(ChA(ndx,n),1,varargin{DrnX});
+	[~,idn] = sort(NuA(ndx,n),1,varargin{DrnX});
+	% ...keep only relevant indices:
+	jdc = ChI(ndx(idc),n); % character
+	jdn = NuI(ndx(idn),n); % number
+	jde = ~ChI(ndx,n)&~NuI(ndx,n); % empty
+	% ...define the sort-order of numbers and characters:
+	jdo = any(RsoA)|(~any(RsoB)&C<'0');
+	% ...then combine these indices in the requested direction:
+	if any(DrnD) % descending
+		idx = [idc(jdc&~jdo);idn(jdn);idc(jdc&jdo);ide(jde)];
+	else % ascending
+		idx = [ide(jde);idc(jdc&jdo);idn(jdn);idc(jdc&~jdo)];
+	end
+	ndx = ndx(idx);
+end
+%
+ndx  = reshape(ndx,size(X));
+X = X(ndx);
+%
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%natsort

--- a/file_exchange/natsortfiles/natsortfiles.m
+++ b/file_exchange/natsortfiles/natsortfiles.m
@@ -1,0 +1,169 @@
+function [X,ndx,dbg] = natsortfiles(X,varargin)
+% Alphanumeric / Natural-Order sort of a cell array of filename/filepath strings (1xN char).
+%
+% (c) 2012 Stephen Cobeldick
+%
+% Alphanumeric sort of a cell array of filenames or filepaths: sorts by
+% character order and also by the values of any numbers that are within
+% the names. Filenames, file-extensions, and directories (if supplied)
+% are split apart and are sorted separately: this ensures that shorter
+% filenames sort before longer ones (i.e. thus giving a dictionary sort).
+%
+%%% Example:
+% D = 'C:\Test';
+% S = dir(fullfile(D,'*.txt'));
+% N = natsortfiles({S.name});
+% for k = 1:numel(N)
+%     fullfile(D,N{k})
+% end
+%
+%%% Syntax:
+%  Y = natsortfiles(X)
+%  Y = natsortfiles(X,xpr)
+%  Y = natsortfiles(X,xpr,<options>)
+% [Y,ndx] = natsortfiles(X,...)
+% [Y,ndx,dbg] = natsortfiles(X,...)
+%
+% To sort all of the strings in a cell array use NATSORT (File Exchange 34464).
+% To sort the rows of a cell array of strings use NATSORTROWS (File Exchange 47433).
+%
+% See also NATSORT NATSORTROWS SORT CELLSTR IREGEXP REGEXP SSCANF DIR FILEPARTS FULLFILE
+%
+%% File Dependency %%
+%
+% NATSORTFILES requires the function NATSORT (File Exchange 34464). The inputs
+% <xpr> and <options> are passed directly to NATSORT: see NATSORT for case
+% sensitivity, sort direction, numeric substring matching, and other options.
+%
+%% Explanation %%
+%
+% Using SORT on filenames will sort any of char(0:45), including the printing
+% characters ' !"#$%&''()*+,-', before the file extension separator character '.'.
+% Therefore this function splits the name and extension and sorts them separately.
+%
+% Similarly the file separator character within filepaths can cause longer
+% directory names to sort before shorter ones, as char(0:46)<'/' and char(0:91)<'\'.
+% NATSORTFILES splits filepaths at each file separator character and sorts
+% every level of the directory hierarchy separately, ensuring that shorter
+% directory names sort before longer, regardless of the characters in the names.
+%
+%% Examples %%
+%
+% A = {'a2.txt', 'a10.txt', 'a1.txt'};
+% sort(A)
+%  ans = 'a1.txt'  'a10.txt'  'a2.txt'
+% natsortfiles(A)
+%  ans = 'a1.txt'  'a2.txt'  'a10.txt'
+%
+% B = {'test_new.m'; 'test-old.m'; 'test.m'};
+% sort(B)         % Note '-' sorts before '.':
+%  ans =
+%    'test-old.m'
+%    'test.m'
+%    'test_new.m'
+% natsortfiles(B) % Shorter names before longer (dictionary sort):
+%  ans =
+%    'test.m'
+%    'test-old.m'
+%    'test_new.m'
+%
+% C = {'test2.m'; 'test10-old.m'; 'test.m'; 'test10.m'; 'test1.m'};
+% sort(C)         % Wrong numeric order:
+%  ans =
+%    'test.m'
+%    'test1.m'
+%    'test10-old.m'
+%    'test10.m'
+%    'test2.m'
+% natsortfiles(C) % Correct numeric order, shorter names before longer:
+%  ans =
+%    'test.m'
+%    'test1.m'
+%    'test2.m'
+%    'test10.m'
+%    'test10-old.m'
+%
+%%% Directory Names:
+% D = {'A2-old\test.m';'A10\test.m';'A2\test.m';'A1archive.zip';'A1\test.m'};
+% sort(D)         % Wrong numeric order, and '-' sorts before '\':
+%  ans =
+%    'A10\test.m'
+%    'A1\test.m'
+%    'A1archive.zip'
+%    'A2-old\test.m'
+%    'A2\test.m'
+% natsortfiles(D) % Shorter names before longer (dictionary sort):
+%  ans =
+%    'A1archive.zip'
+%    'A1\test.m'
+%    'A2\test.m'
+%    'A2-old\test.m'
+%    'A10\test.m'
+%
+%% Input and Output Arguments %%
+%
+% See NATSORT for a full description of <xpr> and the <options>.
+%
+%%% Inputs (*=default):
+%  X   = CellArrayOfCharRowVectors, with filenames or filepaths to be sorted.
+%  xpr = CharRowVector, regular expression to detect numeric substrings, '\d+'*.
+%  <options> can be supplied in any order and are passed directly to NATSORT.
+%
+%%% Outputs:
+%  Y   = CellArrayOfCharRowVectors, filenames of <X> sorted into natural-order.
+%  ndx = NumericMatrix, same size as <X>. Indices such that Y = X(ndx).
+%  dbg = CellVectorOfCellArrays, size 1xMAX(2+NumberOfDirectoryLevels).
+%        Each cell contains the debug cell array for directory names,
+%        filenames, or file extensions. To help debug <xpr>. See NATSORT.
+%
+% [Y,ndx,dbg] = natsortfiles(X,*xpr,<options>)
+
+%% Input Wrangling %%
+%
+assert(iscell(X),'First input <X> must be a cell array.')
+tmp = cellfun('isclass',X,'char') & cellfun('size',X,1)<2 & cellfun('ndims',X)<3;
+assert(all(tmp(:)),'First input <X> must be a cell array of strings (1xN character).')
+%
+%% Split and Sort File Names/Paths %%
+%
+% Split full filepaths into file [path,name,extension]:
+[pth,fnm,ext] = cellfun(@fileparts,X(:),'UniformOutput',false);
+% Split path into {dir,subdir,subsubdir,...}:
+pth = regexp(pth,'[^/\\]+','match'); % either / or \ as filesep.
+len = cellfun('length',pth);
+num = max(len);
+vec{numel(len)} = [];
+%
+% Natural-order sort of the file extensions and filenames:
+if nargout<3 % faster:
+	[~,ndx] = natsort(ext,varargin{:});
+	[~,ids] = natsort(fnm(ndx),varargin{:});
+else % for debugging:
+	[~,ndx,dbg{num+2}] = natsort(ext,varargin{:});
+	[~,ids,tmp] = natsort(fnm(ndx),varargin{:});
+	[~,idd] = sort(ndx);
+	dbg{num+1} = tmp(idd,:);
+end
+ndx = ndx(ids);
+%
+% Natural-order sort of the directory names:
+for k = num:-1:1
+	idx = len>=k;
+	vec(:) = {''};
+	vec(idx) = cellfun(@(c)c(k),pth(idx));
+	if nargout<3 % faster:
+		[~,ids] = natsort(vec(ndx),varargin{:});
+	else % for debugging:
+		[~,ids,tmp] = natsort(vec(ndx),varargin{:});
+		[~,idd] = sort(ndx);
+		dbg{k} = tmp(idd,:);
+	end
+	ndx = ndx(ids);
+end
+%
+% Return the sorted array and indices:
+ndx = reshape(ndx,size(X));
+X = X(ndx);
+%
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%natsortfiles

--- a/file_exchange/natsortfiles/natsortfiles_doc.m
+++ b/file_exchange/natsortfiles/natsortfiles_doc.m
@@ -1,0 +1,109 @@
+%% NATSORTFILES Examples
+% The function <https://www.mathworks.com/matlabcentral/fileexchange/47434
+% |NATSORTFILES|> sorts a cell array of filenames or filepaths (1xN char),
+% taking into account any number values within the strings. This is known
+% as a _natural order sort_ or an _alphanumeric sort_. Note that MATLAB's
+% inbuilt <http://www.mathworks.com/help/matlab/ref/sort.html |SORT|> function
+% sorts the character codes only (as does |SORT| in most programming languages).
+%
+% |NATSORTFILES| is not a naive natural-order sort, but splits and sorts
+% filenames and file extensions separately, which means that |NATSORTFILES|
+% sorts shorter filenames before longer ones: this is known as a _dictionary
+% sort_. For the same reason filepaths are split at every path-separator
+% character (either |'\'| or |'/'|), and each directory level is sorted
+% separately. See the "Explanation" sections below for more details.
+%
+% For sorting the rows of a cell array of strings use
+% <https://www.mathworks.com/matlabcentral/fileexchange/47433 |NATSORTROWS|>.
+%
+% For sorting a cell array of strings use
+% <https://www.mathworks.com/matlabcentral/fileexchange/34464 |NATSORT|>.
+%
+%% Basic Usage
+% By default |NATSORTFILES| interprets consecutive digits as being part of
+% a single integer, each number is considered to be as wide as one letter:
+A = {'a2.txt', 'a10.txt', 'a1.txt'};
+sort(A)
+natsortfiles(A)
+%% Output 2: Sort Index
+% The second output argument is a numeric array of the sort indices |ndx|,
+% such that |Y = X(ndx)| where |Y = natsortfiles(X)|:
+[~,ndx] = natsortfiles(A)
+%% Output 3: Debugging Array
+% The third output is a cell vector of cell arrays, where each cell array
+% contains individual characters and numbers (after converting to numeric).
+% This is useful for confirming that the numbers are being correctly
+% identified by the regular expression. The cells of the cell vector
+% correspond to the split directories, filenames, and file extensions. 
+% Note that the rows of the debugging cell arrays are
+% <https://www.mathworks.com/company/newsletters/articles/matrix-indexing-in-matlab.html
+% linearly indexed> from the input cell array.
+[~,~,dbg] = natsortfiles(A);
+dbg{:}
+%% Example with DIR and a Cell Array
+% One common situation is to use <https://www.mathworks.com/help/matlab/ref/dir.html
+% |DIR|> to identify files in a folder, sort them into the correct order,
+% and then loop over them: below is an example of how to do this.
+% Remember to <https://www.mathworks.com/help/matlab/matlab_prog/preallocating-arrays.html
+% preallocate> all output arrays before the loop!
+D = 'natsortfiles_test'; % directory path
+S = dir(fullfile(D,'*.txt')); % get list of files in directory
+N = natsortfiles({S.name}); % sort file names into order
+for k = 1:numel(N)
+	disp(fullfile(D,N{k}))
+end
+%% Example with DIR and a Structure
+% Users who need to access the |DIR| structure fields can use |NATSORTFILE|'s
+% second output to sort |DIR|'s output structure into the correct order:
+D = 'natsortfiles_test'; % directory path
+S = dir(fullfile(D,'*.txt')); % get list of files in directory
+[~,ndx] = natsortfiles({S.name}); % indices of correct order
+S = S(ndx); % sort structure using indices
+for k = 1:numel(S)
+	fprintf('%-13s%s\n',S(k).name,S(k).date)
+end
+%% Explanation: Dictionary Sort
+% Filenames and file extensions are separated by the extension separator:
+% the period character |'.'|. Using a normal |SORT| the period gets sorted
+% _after_ all of the characters from 0 to 45 (including |!"#$%&'()*+,-|,
+% the space character, and all of the control characters, e.g. newlines,
+% tabs, etc). This means that a naive |SORT| or natural-order sort will
+% sort some short filenames after longer filenames. In order to provide
+% the correct dictionary sort, with shorter filenames first, |NATSORTFILES|
+% splits and sorts filenames and file extensions separately:
+B = {'test_ccc.m'; 'test-aaa.m'; 'test.m'; 'test.bbb.m'};
+sort(B) % '-' sorts before '.'
+natsort(B) % '-' sorts before '.'
+natsortfiles(B) % correct dictionary sort
+%% Explanation: Filenames
+% |NATSORTFILES| combines a dictionary sort with a natural-order sort, so
+% that the number values within the filenames are taken into consideration:
+C = {'test2.m'; 'test10-old.m'; 'test.m'; 'test10.m'; 'test1.m'};
+sort(C) % Wrong numeric order.
+natsort(C) % Correct numeric order, but longer before shorter.
+natsortfiles(C) % Correct numeric order and dictionary sort.
+%% Explanation: Filepaths
+% For the same reason, filepaths are split at each file path separator
+% character (both |'/'| and |'\'| are considered to be file path separators)
+% and every level of directory names are sorted separately. This ensures
+% that the directory names are sorted with a dictionary sort and that any
+% numbers are taken into consideration:
+D = {'A2-old\test.m';'A10\test.m';'A2\test.m';'AXarchive.zip';'A1\test.m'};
+sort(D) % Wrong numeric order, and '-' sorts before '\':
+natsort(D) % correct numeric order, but longer before shorter.
+natsortfiles(D) % correct numeric order and dictionary sort.
+%% Regular Expression: Decimal Numbers, E-notation, +/- Sign
+% |NATSORTFILES| is a wrapper for |NATSORT|, which means all of |NATSORT|'s
+% options are also supported. In particular the number recognition can be
+% customized to detect numbers with decimal digits, E-notation, a +/- sign,
+% or other specific features. This detection is defined by providing an
+% appropriate regular expression: see |NATSORT| for details and examples.
+E = {'test24.csv','test1.8.csv','test5.csv','test3.3.csv','test12.csv'};
+natsortfiles(E,'\d+\.?\d*')
+%% Regular Expression: Interactive Regular Expression Tool
+% Regular expressions are powerful and compact, but getting them right is
+% not always easy. One assistance is to download my interactive tool
+% <https://www.mathworks.com/matlabcentral/fileexchange/48930 |IREGEXP|>,
+% which lets you quickly try different regular expressions and see all of
+% <https://www.mathworks.com/help/matlab/ref/regexp.html |REGEXP|>'s
+% outputs displayed and updated as you type.

--- a/file_exchange/parfor_progress/parfor_progress.m
+++ b/file_exchange/parfor_progress/parfor_progress.m
@@ -41,6 +41,10 @@ end
 
 percent = 0;
 progressLength = 0;
+
+if usejava('desktop')==0
+    return;
+end
 return;
 w = 50; % Width of progress bar
 saveDir = 'private';

--- a/hdf5/readHDF5Subset.m
+++ b/hdf5/readHDF5Subset.m
@@ -1,4 +1,4 @@
-function [dataSubset] = readHDF5Subset(inputFilePath, offset, block, varargin)
+function [dataSubset fid] = readHDF5Subset(inputFilePath, offset, block, varargin)
 	% Gets a subset of data from an HDF5 file.
 	% Biafra Ahanonu
 	% started: 2013.11.10
@@ -14,11 +14,20 @@ function [dataSubset] = readHDF5Subset(inputFilePath, offset, block, varargin)
 		% 2014.01.15 [09:59:53] cleaned up code, removed unnecessary options
 		% 2017.01.18 [15:01:15] added option to deal with 3D data in 4D format with singleton 4th dimension
 		% 2018.09.28 - changed so can read from multiple non-contiguous	slabs of data at the same time
+		% 2019.02.13 [14:52:33] - Updated to support not closing file ID and importing an existing file ID to improve speed.
+		% 2019.02.13 - Updated to support when user ask for multiple offsets at the same location in file.
+		% 2019.02.13 [17:57:55] - Improved duplicate frame support, finds differences in frames, loads all unique as a single slab, then loads remaining and re-organizes to be in correct order.
+	% TODO
+		% DONE: Make support for duplicate frames more robust so minimize the number of file reads.
 
 	%========================
 	% old way of saving, only temporary until full switch
 	options.datasetName = '/1';
 	options.displayInfo = 1;
+	%
+	options.keepFileOpen = 0;
+	%
+	options.hdf5Fid = [];
 	% get options
 	options = getOptions(options,varargin);
 	% unpack options into current workspace
@@ -56,7 +65,13 @@ function [dataSubset] = readHDF5Subset(inputFilePath, offset, block, varargin)
 
 	% open fid to hdf5 dataset
 	plist = 'H5P_DEFAULT';
-	fid = H5F.open(inputFilePath);
+	if isempty(options.hdf5Fid)
+		fid = H5F.open(inputFilePath);
+	else
+		fid = options.hdf5Fid;
+    end
+    % options.hdf5Fid
+    % fid
 	dset_id = H5D.open(fid,options.datasetName);
 	dims = fliplr(block{1});%[xDim yDim 1]
     tmpVar = sum(cat(1,block{:}),1);
@@ -65,28 +80,94 @@ function [dataSubset] = readHDF5Subset(inputFilePath, offset, block, varargin)
 	file_space_id = H5D.get_space(dset_id);
 
 	try
-        for sNo = 1:nSlabs
-            % offset and size of the block to get, flip dimensions so in format that H5S wants
-            offsetFlip = fliplr(offset{sNo});
-            blockFlip = fliplr(block{sNo});
+		offSetAll = cat(1,offset{:});
+		offSetUnique = unique(offSetAll,'rows');
+		% Check if there are duplicates (read in each frame-by-frame if so) else continue as normal.
+		if size(offSetAll)==size(offSetUnique)
+	        for sNo = 1:nSlabs
+	            % offset and size of the block to get, flip dimensions so in format that H5S wants
+	            offsetFlip = fliplr(offset{sNo});
+	            blockFlip = fliplr(block{sNo});
 
-            % select the hyperslab
-            % H5S.select_hyperslab(file_space_id,'H5S_SELECT_SET',offsetFlip,[],[],blockFlip);
+	            % select the hyperslab
+	            % H5S.select_hyperslab(file_space_id,'H5S_SELECT_SET',offsetFlip,[],[],blockFlip);
 
-            % select the hyperslab
-            if sNo==1
-                H5S.select_hyperslab(file_space_id,'H5S_SELECT_SET',offsetFlip,[],[],blockFlip);
-            else
-                H5S.select_hyperslab(file_space_id,'H5S_SELECT_OR',offsetFlip,[],[],blockFlip);
-            end
-            %output = H5S.select_valid(file_space_id)
-            %[start,finish] = H5S.get_select_bounds(file_space_id)
-            % select the data subset
-        end
-		dataSubset = H5D.read(dset_id,'H5ML_DEFAULT',mem_space_id,file_space_id,plist);
+	            % select the hyperslab
+	            if sNo==1
+	                H5S.select_hyperslab(file_space_id,'H5S_SELECT_SET',offsetFlip,[],[],blockFlip);
+	            else
+	                H5S.select_hyperslab(file_space_id,'H5S_SELECT_OR',offsetFlip,[],[],blockFlip);
+	            end
+	            %output = H5S.select_valid(file_space_id)
+	            %[start,finish] = H5S.get_select_bounds(file_space_id)
+	            % select the data subset
+	        end
+			dataSubset = H5D.read(dset_id,'H5ML_DEFAULT',mem_space_id,file_space_id,plist);
+		else
+			display('Input offsets not unique! Using backup method.')
+			% dataSubset = {};
+			offSetAll = cat(1,offset{:});
+			blockAll = cat(1,block{:});
+
+			[offSetUniqueTmp,keptIdx,uniqueGroupsIdx] = unique(offSetAll,'stable','rows');
+			offSetUnique = offset(keptIdx);
+			blockUnique = block(keptIdx);
+			% cat(1,offSetUnique{:})
+
+			dims = fliplr(blockUnique{1});%[xDim yDim 1]
+		    tmpVar = sum(cat(1,blockUnique{:}),1);
+		    dims(1) = tmpVar(3);
+			mem_space_id = H5S.create_simple(length(dims),dims,dims);
+			file_space_id = H5D.get_space(dset_id);
+
+			nSlabsTmp = length(offSetUnique);
+
+	        for sNoTmp = 1:nSlabsTmp
+	            % offset and size of the block to get, flip dimensions so in format that H5S wants
+	            offsetFlip = fliplr(offSetUnique{sNoTmp});
+	            blockFlip = fliplr(blockUnique{sNoTmp});
+
+	            % select the hyperslab
+	            % H5S.select_hyperslab(file_space_id,'H5S_SELECT_SET',offsetFlip,[],[],blockFlip);
+
+	            % select the hyperslab
+	            if sNoTmp==1
+	                H5S.select_hyperslab(file_space_id,'H5S_SELECT_SET',offsetFlip,[],[],blockFlip);
+	            else
+	                H5S.select_hyperslab(file_space_id,'H5S_SELECT_OR',offsetFlip,[],[],blockFlip);
+	            end
+	            %output = H5S.select_valid(file_space_id)
+	            %[start,finish] = H5S.get_select_bounds(file_space_id)
+	            % select the data subset
+	            % [dataSubset{sNo}] = readHDF5Subset(inputFilePath, offset{sNoTmp}, block{sNoTmp},'options',options);
+	        end
+			dataSubset = H5D.read(dset_id,'H5ML_DEFAULT',mem_space_id,file_space_id,plist);
+			% dataSubset = cat(3,dataSubset{:});
+
+			idList = 1:nSlabs;
+			remainIdx = idList(setdiff(idList,keptIdx));
+			offSetRemain = offset(remainIdx);
+			blockRemain = block(remainIdx);
+			nSlabsTmp = length(offSetRemain);
+			dataSubsetRemain = {};
+			for sNoTmp = 1:nSlabsTmp
+				% offsetFlip = fliplr(offSetUnique{sNoTmp});
+				% blockFlip = fliplr(blockUnique{sNoTmp});
+				[dataSubsetRemain{sNoTmp}] = readHDF5Subset(inputFilePath, offSetRemain{sNoTmp}, blockRemain{sNoTmp},'options',options);
+			end
+			dataSubsetRemain = cat(3,dataSubsetRemain{:});
+
+			dataSubset = cat(3,dataSubset,dataSubsetRemain);
+			[newIdx,oldIdx] = sort([keptIdx(:);remainIdx(:)]');
+			% rearrangeIdx =
+			dataSubset(:,:,newIdx) = dataSubset(:,:,oldIdx);
+		end
 	catch err
-        cat(1,offset{:})
-        cat(1,block{:})
+        % x = 1
+        offsetError = cat(1,offset{:})
+        blockError = cat(1,block{:})
+        size(offset)
+        size(block)
 		display(repmat('@',1,7))
 		disp(getReport(err,'extended','hyperlinks','on'));
 		display(repmat('@',1,7))
@@ -115,7 +196,10 @@ function [dataSubset] = readHDF5Subset(inputFilePath, offset, block, varargin)
 	% close IDs
 	H5S.close(file_space_id);
 	H5D.close(dset_id);
-	H5F.close(fid);
+	if options.keepFileOpen==1
+	else
+		H5F.close(fid);
+	end
 
 	% output file size
 	j = whos('dataSubset');j.bytes=j.bytes*9.53674e-7;

--- a/image/computeImageFeatures.m
+++ b/image/computeImageFeatures.m
@@ -69,11 +69,11 @@ function [imgStats] = computeImageFeatures(inputImages, varargin)
 
     % loop over images and get their stats
     for imageNo = 1:nImages
-        iImage = squeeze(inputImages(:,:,imageNo));
+        % iImage = squeeze(inputImages(:,:,imageNo));
         % imagesc(iImage)
         % imgStats.imageSizes(imageNo) = sum(iImage(:)>0);
         if options.runRegionprops==1
-            regionStat = regionprops(iImage, featureList);
+            regionStat = regionprops(inputImages(:,:,imageNo), featureList);
             for ifeature = featureList
                 % regionStat = regionprops(iImage, ifeature{1});
                 try
@@ -87,10 +87,10 @@ function [imgStats] = computeImageFeatures(inputImages, varargin)
         end
 
         if options.addedFeatures==1
-            iImage2 = squeeze(options.addedFeaturesInputImages(:,:,imageNo));
+            % iImage2 = squeeze(options.addedFeaturesInputImages(:,:,imageNo));
             % figure(11);imagesc(iImage2);title(num2str(imageNo))
             % [imageNo xCoords(imageNo) yCoords(imageNo)]
-            t1=getObjCutMovie(iImage2,iImage2,'cropSize',30,'createMontage',0,'crossHairsOn',0,'addPadding',1,'waitbarOn',0,'xCoords',xCoords(imageNo),'yCoords',yCoords(imageNo));
+            t1=getObjCutMovie(options.addedFeaturesInputImages(:,:,imageNo),options.addedFeaturesInputImages(:,:,imageNo),'cropSize',30,'createMontage',0,'crossHairsOn',0,'addPadding',1,'waitbarOn',0,'xCoords',xCoords(imageNo),'yCoords',yCoords(imageNo));
             t1 = t1{1};
             imgStats.imgKurtosis(imageNo) = double(kurtosis(t1(:)));
             imgStats.imgSkewness(imageNo) = double(skewness(t1(:)));

--- a/image/createPeakTriggeredImages.m
+++ b/image/createPeakTriggeredImages.m
@@ -80,9 +80,9 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 			options.inputImagesThres = [];
 			options.thresholdImages = 1;
 		elseif ~isempty(options.thresholdImages)
-			inputImagesThres = thresholdImages(inputImages,'waitbarOn',1,'binary',1,'threshold',options.thresholdImages);
+			inputImagesThres = thresholdImages(inputImages,'waitbarOn',options.waitbarOn,'binary',1,'threshold',options.thresholdImages);
 		else
-			inputImagesThres = thresholdImages(inputImages,'waitbarOn',1,'binary',1,'threshold',0.4);
+			inputImagesThres = thresholdImages(inputImages,'waitbarOn',options.waitbarOn,'binary',1,'threshold',0.4);
 		end
 
 		if isempty(options.signalPeaksArray)

--- a/image/createPeakTriggeredImages.m
+++ b/image/createPeakTriggeredImages.m
@@ -133,7 +133,7 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 		options_runSecondCorr = options.runSecondCorr;
 		options_outputImageFlag = options.outputImageFlag;
 
-		options_maxPeaksToUse
+		% options_maxPeaksToUse
 
 		disp('Starting movie images...')
 		display(repmat('.',1,round(nSignals/20)))

--- a/image/createPeakTriggeredImages.m
+++ b/image/createPeakTriggeredImages.m
@@ -18,7 +18,7 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 		% Take 2 frames after peak and average to improve SNR
 
 	%========================
-	% size in pixels to crop around the movie
+	% Int: size in pixels to crop in the movie around cell centroid
 	options.cropSize = 10;
 	% hierarchy name in hdf5 where movie is
 	options.inputDatasetName = '/1';
@@ -48,6 +48,12 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 	options.runSecondCorr = 0;
 	%
 	options.outputImageFlag = 1;
+	% Int: Number of frames after event to average movie
+	options.nFramesMeanTrigger = 1;
+	% FID of the inputMovie via H5F.open to save time
+	options.hdf5Fid = [];
+	% Whether to keep HDF5 file open (for FID)
+	options.keepFileOpen = 0;
 	% get options
 	options = getOptions(options,varargin);
 	% display(options)
@@ -70,6 +76,11 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 				movieDims = loadMovieList(inputMovie,'inputDatasetName',options.inputDatasetName,'getMovieDims',1);
 				movieDims = [movieDims.one movieDims.two movieDims.three];
 			end
+
+			% Force read movie chunks to be 1
+			% options.readMovieChunks = 1;
+			options.hdf5Fid = H5F.open(inputMovie);
+			options.keepFileOpen = 1;
 		else
 			movieDims = size(inputMovie);
 		end
@@ -113,7 +124,7 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 		outputMeanImageCorr2 = [];
 		outputMeanImageCorrMax = [];
 
-		reverseStr = '';
+		% reverseStr = '';
 		% loop over all signals
 
 		outputMeanImageStruct_corrPearson = [];
@@ -133,6 +144,9 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 		options_runSecondCorr = options.runSecondCorr;
 		options_outputImageFlag = options.outputImageFlag;
 
+		options_hdf5Fid = options.hdf5Fid;
+		options_keepFileOpen = options.keepFileOpen;
+
 		% options_maxPeaksToUse
 
 		disp('Starting movie images...')
@@ -149,7 +163,7 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 			D = parallel.pool.DataQueue;
 			afterEach(D, @nUpdateParforProgress);
 			p = 1;
-			N = nSignals;
+			% N = nSignals;
 		end
 		% nInterval = round(nSignals/20);
 		nInterval = 20;
@@ -188,7 +202,8 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 				signalPeaksThis = unique(signalPeaksThis);
 				nPeaksToUse = length(signalPeaksThis);
 				if ~isempty(options_maxPeaksToUse)
-					thisTrace = inputSignals(signalNo,:);
+					% thisTrace = inputSignals(signalNo,:);
+					thisTrace = inputSignals{signalNo};
 					peakSignalAmplitude = thisTrace(signalPeaksThis);
 					[~, peakIdx] = sort(peakSignalAmplitude,'descend');
 					signalPeaksThis = signalPeaksThis(peakIdx);
@@ -207,12 +222,13 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 
 		xMax = movieDims(2);
 		yMax = movieDims(1);
-		nFrames = size(inputSignals,2);
+		% nFrames = size(inputSignals,2);
+		nFrames = size(inputSignals{1},2);
 
 		parfor(signalNo = 1:nSignals,nWorkers)
 		% for signalNo = 1:nSignals
 			try
-				if isnan(xCoords(signalNo))|isnan(yCoords(signalNo))
+				if isnan(xCoords(signalNo))||isnan(yCoords(signalNo))
 					outputMeanImageCorrs(signalNo) = NaN;
 					outputMeanImageCorrsMean(signalNo) = NaN;
 					outputMeanImageCorr2(signalNo) = NaN;
@@ -247,7 +263,8 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 				signalPeaksThis = unique(signalPeaksThis);
 				nPeaksToUse = length(signalPeaksThis);
 				if ~isempty(options_maxPeaksToUse)
-					thisTrace = inputSignals(signalNo,:);
+					% thisTrace = inputSignals(signalNo,:);
+					thisTrace = inputSignals{signalNo};
 					peakSignalAmplitude = thisTrace(signalPeaksThis);
 					[~, peakIdx] = sort(peakSignalAmplitude,'descend');
 					signalPeaksThis = signalPeaksThis(peakIdx);
@@ -299,7 +316,7 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 						% 	signalImagesCrop = cat(3,signalImagesCrop,signalImagesCropTmp);
 						% end
 					end
-					[signalImagesCrop] = readHDF5Subset(inputMovie, offset, block,'datasetName',options_inputDatasetName,'displayInfo',0);
+					[signalImagesCrop] = readHDF5Subset(inputMovie, offset, block,'datasetName',options_inputDatasetName,'displayInfo',0,'hdf5Fid',options_hdf5Fid,'keepFileOpen',options_keepFileOpen);
 					%signalImagesCrop = cat(3,signalImagesCrop{:});
 				end
 				% corrVals = [];
@@ -322,6 +339,10 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 					szA = size(A);
 					szB = size(B);
 					szB(3) = 1;
+					% If only have a single peak, compensate for that.
+					if length(szA)==2
+						szA(3) = 1;
+					end
 					dim12 = szA(1)*szA(2);
 
 					a1 = bsxfun(@minus,A,mean(reshape(A,dim12,1,[])));
@@ -499,16 +520,19 @@ function [outputImages, outputMeanImageCorrs, outputMeanImageCorr2, outputMeanIm
 		end
 	end
 	function convertInputImagesToCell()
-		%Get dimension information about 3D movie matrix
+		% Convert input signals into cell array
+		inputSignals = squeeze(mat2cell(inputSignals,ones(1,size(inputSignals,1)),size(inputSignals,2)));
+
+		% Get dimension information about 3D movie matrix
 		[inputMovieX, inputMovieY, inputMovieZ] = size(inputImages);
-		%reshapeValue = size(inputImages);
-		%Convert array to cell array, allows slicing (not contiguous memory block)
+		% reshapeValue = size(inputImages);
+		% Convert array to cell array, allows slicing (not contiguous memory block)
 		inputImages = squeeze(mat2cell(inputImages,inputMovieX,inputMovieY,ones(1,inputMovieZ)));
 
-		%Get dimension information about 3D movie matrix
+		% Get dimension information about 3D movie matrix
 		[inputMovieX, inputMovieY, inputMovieZ] = size(inputImagesThres);
-		%reshapeValue = size(inputImagesThres);
-		%Convert array to cell array, allows slicing (not contiguous memory block)
+		% reshapeValue = size(inputImagesThres);
+		% Convert array to cell array, allows slicing (not contiguous memory block)
 		inputImagesThres = squeeze(mat2cell(inputImagesThres,inputMovieX,inputMovieY,ones(1,inputMovieZ)));
 	end
 end

--- a/image/thresholdImages.m
+++ b/image/thresholdImages.m
@@ -16,6 +16,7 @@ function [inputImages, boundaryIndices] = thresholdImages(inputImages,varargin)
         % 2014.03.13 slight change to support double and other non-integer images
         % 2017.01.14 [20:06:04] - support switched from [nSignals x y] to [x y nSignals]
         % 2017 or 2018 - added boundaryIndices support.
+        % 2019.03.05 [19:21:30] Change to using bwareafilt to remove unconnected points from main structure
     % TODO
         %
 
@@ -105,6 +106,7 @@ function [inputImages, boundaryIndices] = thresholdImages(inputImages,varargin)
     replaceVal = 0;
     parfor(imageNo=1:nImages,nWorkers)
         thisFilt = squeeze(inputImages{imageNo});
+        % thisFilt = inputImages(:,:,imageNo);
         % if cellLoad==1
         % else
             % thisFilt = squeeze(inputImages(:,:,imageNo));
@@ -147,13 +149,16 @@ function [inputImages, boundaryIndices] = thresholdImages(inputImages,varargin)
                 % Remove any pixels not connected to the image max value if there is a filter with max values at the edge, try...catch to get around errors
                 try
                     % [indx indy] = find(thisFilt==1); %Find the maximum
-                    [B,nObjs] = bwlabeln(thisFilt);
-                    objsN = [];
-                    for iii = 1:nObjs
-                       objsN(iii) = length(find(B==iii));
-                    end
-                    [~,idxH] = max(objsN);
-                    thisFilt(B~=idxH) = 0;
+                    % [B,nObjs] = bwlabeln(thisFilt);
+                    % objsN = [];
+                    % for iii = 1:nObjs
+                    %    objsN(iii) = length(find(B==iii));
+                    % end
+                    % [~,idxH] = max(objsN);
+                    % thisFilt(B~=idxH) = 0;
+
+                    thisFilt = bwareafilt(thisFilt,1);
+
                     %thisFilt(B~=B(indx,indy)) = 0;
                     % B = bwlabeln(thisFilt);
                 catch
@@ -179,18 +184,21 @@ function [inputImages, boundaryIndices] = thresholdImages(inputImages,varargin)
             % Remove any pixels not connected to the image max value if there is a filter with max values at the edge, try...catch to get around errors
             try
                 % [indx indy] = find(thisFilt==1); %Find the maximum
-                [B,nObjs] = bwlabeln(thisFilt2);
-                objsN = [];
-                for iii = 1:nObjs
-                   objsN(iii) = length(find(B==iii));
-                end
-                [~,idxH] = max(objsN);
-                thisFilt(B~=idxH) = 0;
+                % [B,nObjs] = bwlabeln(thisFilt2);
+                % objsN = [];
+                % for iii = 1:nObjs
+                %    objsN(iii) = length(find(B==iii));
+                % end
+                % [~,idxH] = max(objsN);
+                % thisFilt(B~=idxH) = 0;
+
+                thisFilt = bwareafilt(thisFilt,1);
             catch
             end
         end
 
         inputImages{imageNo} = thisFilt;
+        % inputImages(:,:,imageNo) = thisFilt;
         % if cellLoad==1
         % else
             % inputImages(:,:,imageNo)=thisFilt;
@@ -207,13 +215,16 @@ function [inputImages, boundaryIndices] = thresholdImages(inputImages,varargin)
 
             try
                 % [indx indy] = find(thisFilt==1); %Find the maximum
-                [B,nObjs] = bwlabeln(thisFilt);
-                objsN = [];
-                for iii = 1:nObjs
-                   objsN(iii) = length(find(B==iii));
-                end
-                [~,idxH] = max(objsN);
-                thisFilt(B~=idxH) = 0;
+                % [B,nObjs] = bwlabeln(thisFilt);
+                % objsN = [];
+                % for iii = 1:nObjs
+                %    objsN(iii) = length(find(B==iii));
+                % end
+                % [~,idxH] = max(objsN);
+                % thisFilt(B~=idxH) = 0;
+
+                thisFilt = bwareafilt(thisFilt,1);
+
                 %thisFilt(B~=B(indx,indy)) = 0;
                 % B = bwlabeln(thisFilt);
             catch
@@ -253,7 +264,12 @@ function [inputImages, boundaryIndices] = thresholdImages(inputImages,varargin)
         if ~verLessThan('matlab', '9.2')
             p = p + 1;
             if (mod(p,nInterval)==0||p==nImages)&&options_waitbarOn==1
-                cmdWaitbar(p,nImages,'','inputStr','','waitbarOn',1);
+                % cmdWaitbar(p,nImages,'','inputStr','','waitbarOn',1);
+                if p==nImages
+                    fprintf('%d%%\n',round(p/nImages*100))
+                else
+                    fprintf('%d%% | ',round(p/nImages*100))
+                end
             end
         end
     end

--- a/io/getFileList.m
+++ b/io/getFileList.m
@@ -11,10 +11,12 @@ function [fileList] = getFileList(inputDir, filterExp,varargin)
     % changelog
         % 2014.03.21 - added feature to input cell array of filters
         % 2016.03.20 - added exclusion filter to function
+        % 2019.03.08 [13:12:59] - added support for natural sorting of files
     % TODO
         % Fix recusive to recursive in a backwards compatible way
 
     %========================
+    %
     options.recusive = 0;
     %
     options.recursive = '';
@@ -22,6 +24,9 @@ function [fileList] = getFileList(inputDir, filterExp,varargin)
     options.regexpWithFolder = 0;
     %
     options.excludeFilter = '';
+    % Char: lexicographic (e.g. 1 10 11 2 21 22 unless have 01 02 10 11 21 22) or numeric (e.g. 1 2 10 11 21 22) or natural (e.g. 1 2 10 11 21 22)
+    % options.sortMethod = 'lexicographic';
+    options.sortMethod = 'natural';
     % get options
     options = getOptions(options,varargin);
     % display(options)
@@ -75,5 +80,8 @@ function [fileList] = getFileList(inputDir, filterExp,varargin)
         excludeIdx = ~cellfun(@isempty,(regexp(fileList,options.excludeFilter)));
         fileList(excludeIdx) = [];
         % includeIdx = setdiff(1:length(fileList),excludeIdx)
+    end
+    if strcmp(options.sortMethod,'natural')|strcmp(options.sortMethod,'numeric')
+        fileList = natsortfiles(fileList);
     end
 end

--- a/io/getFileList.m
+++ b/io/getFileList.m
@@ -81,7 +81,7 @@ function [fileList] = getFileList(inputDir, filterExp,varargin)
         fileList(excludeIdx) = [];
         % includeIdx = setdiff(1:length(fileList),excludeIdx)
     end
-    if strcmp(options.sortMethod,'natural')|strcmp(options.sortMethod,'numeric')
+    if ~isempty(fileList)&&(strcmp(options.sortMethod,'natural')|strcmp(options.sortMethod,'numeric'))
         fileList = natsortfiles(fileList);
     end
 end

--- a/io/modelAddOutsideDependencies.m
+++ b/io/modelAddOutsideDependencies.m
@@ -46,9 +46,14 @@ function [success] = modelAddOutsideDependencies(dependencyName,varargin)
 						end
 						addpath(pathToMiji);
 					end
-					% Load Miji so paths added to javaclasspath('-dynamic')
-					currP=pwd;Miji;cd(currP);
-					MIJ.exit;
+
+					% Get Miji properly loaded in the path
+					resetMiji;
+
+					% % Load Miji so paths added to javaclasspath('-dynamic')
+					% currP=pwd;Miji;cd(currP);
+					% MIJ.exit;
+
 				end
 			otherwise
 				display('Incorrect option input.')

--- a/io/resetMiji.m
+++ b/io/resetMiji.m
@@ -34,7 +34,7 @@ function [success] = resetMiji(varargin)
 	% try
 	success = 0;
 
-	for i = 1:2
+	for i = 1:1
 		try
 			clear MIJ miji Miji mij;
 			javaDyna = javaclasspath('-dynamic');

--- a/loadBatchFxns.m
+++ b/loadBatchFxns.m
@@ -14,9 +14,10 @@ function loadBatchFxns()
 		pathFilter = cellfun(@isempty,regexpi(pathListArray,[filesep 'cnmfe']));
 		pathFilter1 = cellfun(@isempty,regexpi(pathListArray,[filesep 'cnmf_original']));
 		pathFilter2 = cellfun(@isempty,regexpi(pathListArray,[filesep 'cnmf_current']));
-		pathListArray = pathListArray(pathFilter&pathFilter1&pathFilter2);
+		pathFilter3 = cellfun(@isempty,regexpi(pathListArray,[filesep 'cvx_rd']));
+		pathListArray = pathListArray(pathFilter&pathFilter1&pathFilter2&pathFilter3);
 	else
-		matchIdx = contains(pathListArray,{[filesep 'cnmfe'],[filesep 'cnmf_original'],[filesep 'cnmf_current']});
+		matchIdx = contains(pathListArray,{[filesep 'cnmfe'],[filesep 'cnmf_original'],[filesep 'cnmf_current'],[filesep 'cvx_rd']});
 		pathListArray = pathListArray(~matchIdx);
 	end
 

--- a/loadBatchFxns.m
+++ b/loadBatchFxns.m
@@ -31,6 +31,8 @@ function loadBatchFxns()
 	if exist(pathtoMiji,'dir')~=0
 		addpath(pathtoMiji);
 		fprintf('Added Miji to path: %s.\n',pathtoMiji)
+		% Get Miji properly loaded in the path
+		resetMiji;
 	else
 		clear pathtoMiji;
 	end
@@ -40,6 +42,8 @@ function loadBatchFxns()
 		run(loadLocalFunctions);
 		addpath(pathtoMiji);
 		fprintf('Added Miji to path: %s.\n',pathtoMiji)
+		% Get Miji properly loaded in the path
+		resetMiji;
 	else
 		% create privateLoadBatchFxns.m
 	end

--- a/motion_correction/turboregMovie.m
+++ b/motion_correction/turboregMovie.m
@@ -1,4 +1,4 @@
-function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
+function [inputMovie, ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	% Motion corrects (using turboreg) a movie; both turboreg (to get 2D translation coordinates) and registering images have been parallelized. Can also turboreg to one set of images and apply the registration to another set (e.g. for cross-day alignment).
 	% Biafra Ahanonu
 	% started 2013.11.09 [11:04:18]
@@ -41,7 +41,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	% ================================================
 
 	% check that input is not empty
-	display('starting turboreg...');
+	disp('starting turboreg...');
 	if isempty(inputMovie)
 		return;
 	end
@@ -146,7 +146,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	% check that Miji is present
 	if strcmp(options.normalizeType,'imagejFFT')|strcmp(options.normalizeBeforeRegister,'imagejFFT')
 		if exist('Miji.m','file')==2
-			display(['Miji located in: ' which('Miji.m')]);
+			disp(['Miji located in: ' which('Miji.m')]);
 			% Miji is loaded, continue
 		else
 			pathToMiji = inputdlg('Enter path to Miji.m in Fiji (e.g. \Fiji.app\scripts):',...
@@ -162,7 +162,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	end
 	% ========================
 	inputMovieClass = class(inputMovie);
-	if strcmp(inputMovieClass,'char')
+	if ischar(inputMovie)
 	    inputMovie = loadMovieList(inputMovie,'inputDatasetName',options.inputDatasetName,'frameList',options.frameList);
 	    % [pathstr,name,ext] = fileparts(inputFilePath);
 	    % options.newFilename = [pathstr '\concat_' name '.h5'];
@@ -192,7 +192,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	if ~isempty(options.precomputedRegistrationCooords)
 		ResultsOut = options.precomputedRegistrationCooords;
 		ResultsOutOriginal = ResultsOut;
-		for resultNo=1:size(inputMovie,3);
+		for resultNo=1:size(inputMovie,3)
 			ResultsOutTemp{resultNo} = ResultsOut{options.altMovieRegisterNum};
 		end
 		ResultsOut = ResultsOutTemp;
@@ -243,7 +243,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 			case 'imagejFFT'
 				imagefFftOnInputMovie('inputMovie');
 			case 'divideByLowpass'
-				display('dividing movie by lowpass...')
+				disp('dividing movie by lowpass...')
 				% inputMovie = normalizeMovie(single(inputMovie),'normalizationType','imfilter','blurRadius',20,'waitbarOn',1);
 				inputMovie = normalizeMovie(single(inputMovie),'normalizationType','lowpassFFTDivisive','freqLow',options.freqLow,'freqHigh',options.freqHigh,'waitbarOn',1,'bandpassMask','gaussian');
 				% [inputMovie] = normalizeMovie(single(inputMovie),...
@@ -251,7 +251,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 					% 'freqLow',options.freqLow,'freqHigh',options.freqHigh,...
 					% 'bandpassType','lowpass','showImages',0,'bandpassMask','gaussian');
 			case 'bandpass'
-				display('bandpass filtering...')
+				disp('bandpass filtering...')
 				inputMovie = single(inputMovie);
 				[inputMovie] = normalizeMovie(single(inputMovie),'normalizationType','fft','freqLow',options.freqLow,'freqHigh',options.freqHigh,'bandpassType','bandpass','showImages',0,'bandpassMask','gaussian');
 			otherwise
@@ -261,7 +261,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	% ========================
 	% if cropped movie for turboreg, restore the old input movie for registration
 	if ~isempty(options.altMovieRegister)
-		display(['preparing to register input #' options.altMovieRegisterNum ', converting secondary input movie...'])
+		disp(['preparing to register input #' options.altMovieRegisterNum ', converting secondary input movie...'])
 		% ===
 		% if we are using the turboreg coordinates for frame #options.altMovieRegisterNum to register all frames from options.altMovieRegister, want to give registerMovie an identical sized array to altMovieRegister like it normally expects
 		% this was made for having refCellmap and testCellmap, aligning the testCellmap to the refCellmap then registering all the cell images for testCellmap to refCellmap
@@ -275,13 +275,13 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 		inputMovie = options.altMovieRegister;
 		convertInputMovieToCell();
 	elseif ~isempty(options.cropCoords)
-		display('restoring uncropped movie and converting to cell...');
+		disp('restoring uncropped movie and converting to cell...');
 		clear registeredMovie;
 		%Convert array to cell array, allows slicing (not contiguous memory block)
 		convertInputMovieToCell();
 		% ===
 	else
-		display('converting movie to cell...');
+		disp('converting movie to cell...');
 		%Convert array to cell array, allows slicing (not contiguous memory block)
 		convertInputMovieToCell();
 		% ===
@@ -303,7 +303,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	toc(startTime)
 
 	% ========================
-	display('converting cell array back to matrix')
+	disp('converting cell array back to matrix')
 	%Convert cell array back to 3D matrix
 	inputMovie = cat(3,inputMovie{:});
 	inputMovie = single(inputMovie);
@@ -319,7 +319,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	end
 
 	if ~isempty(options.refFrameMatrix)
-		display('removing ref picture');
+		disp('removing ref picture');
 		% inputMovie = inputMovie(:,:,1:end-1);
 		inputMovie(:,:,end) = [];
 		% refPic = single(squeeze(inputMovie(:,:,options.refFrame)));
@@ -329,7 +329,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 
 	function convertInputMovieToCell()
 		%Get dimension information about 3D movie matrix
-		[inputMovieX inputMovieY inputMovieZ] = size(inputMovie);
+		[inputMovieX, inputMovieY, inputMovieZ] = size(inputMovie);
 		reshapeValue = size(inputMovie);
 		%Convert array to cell array, allows slicing (not contiguous memory block)
 		inputMovie = squeeze(mat2cell(inputMovie,inputMovieX,inputMovieY,ones(1,inputMovieZ)));
@@ -337,7 +337,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 
 	function convertinputMovieCroppedToCell()
 		%Get dimension information about 3D movie matrix
-		[inputMovieX inputMovieY inputMovieZ] = size(inputMovieCropped);
+		[inputMovieX, inputMovieY, inputMovieZ] = size(inputMovieCropped);
 		reshapeValue = size(inputMovieCropped);
 		%Convert array to cell array, allows slicing (not contiguous memory block)
 		inputMovieCropped = squeeze(mat2cell(inputMovieCropped,inputMovieX,inputMovieY,ones(1,inputMovieZ)));
@@ -347,10 +347,10 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	function turboregMovieParallel()
 		% get reference picture and other pre-allocation
 		postProcessPic = single(squeeze(inputMovieCropped(:,:,options.refFrame)));
-		mask=single(ones(size(postProcessPic)));
-		imgRegMask=single(double(mask));
+		mask = single(ones(size(postProcessPic)));
+		imgRegMask = single(double(mask));
 		% we add an offset to be able to give NaN to black borders
-		averagePictureEdge=zeros(size(imgRegMask));
+		averagePictureEdge = zeros(size(imgRegMask));
 		refPic = single(squeeze(inputMovieCropped(:,:,options.refFrame)));
 		% refPic = squeeze(inputMovieCropped(:,:,options.refFrame));
 
@@ -365,17 +365,17 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 		movieClass = class(inputMovieCropped);
 		% you need this FileExchange function for progress in a parfor loop
 		% parfor_progress(options.maxFrame);
-		display('turboreg-ing...');
-		display('');
+		disp('turboreg-ing...');
+		disp('');
 		% parallel for loop, since each turboreg operation is independent, can send each frame to separate workspaces
 		startTurboRegTime = tic;
 		%
 		nFramesToTurboreg = options.maxFrame;
 		if options.parallel==1; nWorkers=Inf;else;nWorkers=0;end
 		% options.maxFrame
-		try;[percent progress] = parfor_progress(nFramesToTurboreg);catch;end; dispStepSize = round(nFramesToTurboreg/20); dispstat('','init');
+		try [percent, progress] = parfor_progress(nFramesToTurboreg);catch;end; dispStepSize = round(nFramesToTurboreg/20); dispstat('','init');
 		parfor (frameNo=1:nFramesToTurboreg,nWorkers)
-			[percent progress] = parfor_progress;
+			[percent, progress] = parfor_progress;
 			% if mod(progress,dispStepSize) == 0;dispstat(sprintf('progress %0.1f %',percent));else;end
 			% get current frames
 			thisFrame = inputMovieCropped{frameNo};
@@ -393,8 +393,8 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 
 	% function registerMovie(movieData,ResultsOut,InterpListSelection,TransformationType,options)
 	function registerMovie()
-		display('registering frames...');
-		display('');
+		disp('registering frames...');
+		disp('');
 		% need to register subsets of the movie so parfor won't crash due to serialization errors
 		% TODO: make this subset based on the size of the movie, e.g. only send 1GB chunks to workers
 		subsetSize = options.subsetSizeFrames;
@@ -402,7 +402,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 		subsetList = round(linspace(1,length(inputMovie),numSubsets));
 		display(['registering sublists: ' num2str(subsetList)]);
 		if options.turboregRotation==1
-			display('Using rotation in registration')
+			disp('Using rotation in registration')
 		end
 		% ResultsOut{1}.Rotation
 		nSubsets = (length(subsetList)-1);
@@ -425,9 +425,9 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
             registrationFxnOption = options.registrationFxn;
             % size(ResultsOut)
             nMovieSubsets = length(movieSubset);
-            try;[percent progress] = parfor_progress(nMovieSubsets);catch;end; dispStepSize = round(nMovieSubsets/20); dispstat('','init');
+            try [percent, progress] = parfor_progress(nMovieSubsets);catch;end; dispStepSize = round(nMovieSubsets/20); dispstat('','init');
 			parfor (i = movieSubset,nWorkers)
-				[percent progress] = parfor_progress;
+				[percent, progress] = parfor_progress;
 				% if mod(progress,dispStepSize) == 0;dispstat(sprintf('progress %0.1f %',percent));else;end
 				% thisFrame = movieDataTemp{i};
 				% get rotation and translation profile for image
@@ -621,7 +621,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 		rectCrop=[xmin ymin xmax-xmin ymax-ymin];
 
 		if options.showFigs==1
-			[figHandle figNo] = openFigure(100, '');
+			[figHandle, figNo] = openFigure(100, '');
 			imagesc(imcrop(inputMovie(:,:,1),rectCrop));
 		end
 		% To get the final size, we just apply on the first figure
@@ -631,7 +631,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 		% end
 	end
 	function imagefFftOnInputMovie(inputMovieName)
-		display('dividing movie by lowpass via imageJ...')
+		disp('dividing movie by lowpass via imageJ...')
 		% inputMovie = normalizeMovie(single(inputMovie),'normalizationType','imagejFFT','waitbarOn',1);
 		% opens imagej
 		% MUST ADD \Fiji.app\scripts
@@ -688,7 +688,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 		% choose whether to save a copy of the lowpass fft
 		% expand this to include the raw turboreg
 		if ~isempty(options.saveNormalizeBeforeRegister)
-			display('saving lowpass...')
+			disp('saving lowpass...')
 			if ~isempty(options.refFrameMatrix)
 				inputMovieFFT = inputMovieFFT(:,:,1:end-1);
 			end
@@ -706,7 +706,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 			inputMovieCropped = inputMovie(cc(2):cc(4), cc(1):cc(3), :);
 			display(['cropped dims: ' num2str(size(inputMovieCropped))])
 		elseif ~isempty(options.cropCoords)
-			display('cropping stack...');
+			disp('cropping stack...');
 			cc = options.cropCoords;
 			inputMovieCropped = inputMovie(cc(2):cc(4), cc(1):cc(3), :);
 			if options.showFigs==1
@@ -733,10 +733,10 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 					imagefFftOnInputMovie('inputMovieCropped');
 				case 'matlabDisk'
 					% single(inputMovieCropped)
-					display('Matlab fspecial disk background removal')
+					disp('Matlab fspecial disk background removal')
 
 					%Get dimension information about 3D movie matrix
-					[inputMovieX inputMovieY inputMovieZ] = size(inputMovieCropped);
+					[inputMovieX, inputMovieY, inputMovieZ] = size(inputMovieCropped);
 					reshapeValue = size(inputMovieCropped);
 					%Convert array to cell array, allows slicing (not contiguous memory block)
 					inputMovieCropped = squeeze(mat2cell(inputMovieCropped,inputMovieX,inputMovieY,ones(1,inputMovieZ)));
@@ -752,7 +752,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 					% nImages = size(inputMovieCropped,3);
 					nImages = length(inputMovieCropped);
 
-					try;[percent progress] = parfor_progress(nImages);catch;end; dispStepSize = round(nImages/20); dispstat('','init');
+					% try [percent, progress] = parfor_progress(nImages);catch;end; dispStepSize = round(nImages/20); dispstat('','init');
 					if options.parallel==1; nWorkers=Inf;else;nWorkers=0;end
 					parfor (imageNo = 1:nImages,nWorkers)
 						% [percent progress] = parfor_progress;if mod(progress,dispStepSize) == 0;dispstat(sprintf('progress %0.1f %',percent));else;end
@@ -766,18 +766,18 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 
 					inputMovieCropped = cat(3,inputMovieCropped{:});
 				case 'divideByLowpass'
-					display('dividing movie by lowpass...')
+					disp('dividing movie by lowpass...')
 					inputMovieCropped = normalizeMovie(single(inputMovieCropped),'normalizationType','imfilter','blurRadius',20,'waitbarOn',1);
 					% inputMovie = normalizeMovie(single(inputMovie),'normalizationType','lowpassFFTDivisive','freqLow',options.freqLow,'freqHigh',options.freqHigh,'waitbarOn',1,'bandpassMask','gaussian');
 					% inputMovieCropped = normalizeMovie(single(inputMovieCropped),'normalizationType','imfilter','blurRadius',20,'waitbarOn',1);
 					% inputMovie = normalizeMovie(single(inputMovie),'normalizationType','lowpassFFTDivisive','freqLow',options.freqLow,'freqHigh',options.freqHigh,'waitbarOn',1);
 					% playMovie(inputMovieCropped);
 				case 'highpass'
-					display('high-pass filtering...')
+					disp('high-pass filtering...')
 					[inputMovieCropped] = normalizeMovie(single(inputMovieCropped),'normalizationType','fft','freqLow',7,'freqHigh',500,'bandpassType','highpass','showImages',0,'bandpassMask','gaussian');
 					% [inputMovieCropped] = normalizeMovie(single(inputMovieCropped),'normalizationType','fft','freqLow',1,'freqHigh',7,'bandpassType','lowpass','showImages',0,'bandpassMask','gaussian');
 				case 'bandpass'
-					display('bandpass...')
+					disp('bandpass...')
 					[inputMovieCropped] = normalizeMovie(single(inputMovieCropped),'normalizationType','fft','freqLow',options.normalizeFreqLow,'freqHigh',options.normalizeFreqHigh,'bandpassType',options.normalizeBandpassType,'showImages',0,'bandpassMask',options.normalizeBandpassMask);
 					% [inputMovieCropped] = normalizeMovie(single(inputMovieCropped),'normalizationType','fft','freqLow',1,'freqHigh',7,'bandpassType','lowpass','showImages',0,'bandpassMask','gaussian');
 				otherwise
@@ -785,9 +785,9 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 			end
 
 			if options.complementMatrix==1
-				display('mean subtracting and complementing matrix...');
+				disp('mean subtracting and complementing matrix...');
 			else
-				display('mean subtracting...');
+				disp('mean subtracting...');
 			end
 			reverseStr = '';
 			for frameInd=1:Ntime
@@ -811,7 +811,7 @@ function [inputMovie ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 		% inputMovieCropped = 255 * (inputMovieCropped/255).^ GammaValue;
 		% playMovie(inputMovieCropped);
 	end
-	display('=======')
+	disp('=======')
 end
 function cropCoords = getCropSelection(thisFrame)
 	% get a crop of the input region

--- a/movie_processing/normalizeMovie.m
+++ b/movie_processing/normalizeMovie.m
@@ -100,43 +100,43 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		case 'matlabFFTTemporal'
 			subfxnMatlabFFTTemporal();
 		case 'matlabFFTTemporal_test'
-			display('Not implemented here.')
+			disp('Not implemented here.')
 			% Nothing here yet
 		case 'imfilterSmooth'
 			subfxnImfilterSmooth();
 		case 'imfilter'
 			subfxnImfilter();
 		case 'meanSubtraction'
-			display('mean subtracting movie');
+			disp('mean subtracting movie');
 			inputMean = nanmean(nanmean(inputMovie,1),2);
 			inputMean = cast(inputMean,class(inputMovie));
 			inputMovie = bsxfun(@minus,inputMovie,inputMean);
 		case 'meanDivision'
-			display('mean dividing movie');
+			disp('mean dividing movie');
 			inputMean = nanmean(nanmean(inputMovie,1),2);
 			inputMean = cast(inputMean,class(inputMovie));
 			inputMovie = bsxfun(@rdivide,inputMovie,inputMean);
 			% inputMean = nansum(nansum(inputMovie,1),2);
 			% inputMean = cast(inputMean,class(inputMovie))
 		case 'negativeRemoval'
-			display('Switching movie negative values to positive (abs)');
-			inputMin = abs(nanmin(inputMovie(:)))
+			disp('Switching movie negative values to positive (abs)');
+			inputMin = abs(nanmin(inputMovie(:)));
 			inputMin = cast(inputMin,class(inputMovie));
 			inputMovie = bsxfun(@plus,inputMovie,inputMin);
 		case 'zeroToOne'
-			display('normalizing movie between 0 and 1');
+			disp('normalizing movie between 0 and 1');
 			nFrames = size(inputMovie,3);
 			reverseStr = '';
-			for frame=1:nFrames
-			    thisFrame = squeeze(inputMovie(:,:,frame));
+			for frameNo2 = 1:nFrames
+			    thisFrame = squeeze(inputMovie(:,:,frameNo2));
 				maxVec = nanmax(thisFrame(:));
 				minVec = nanmin(thisFrame(:));
-				meanVec = nanmean(thisFrame(:));
-				inputMovie(:,:,frame) = (thisFrame-minVec)./(maxVec-minVec);
-			    reverseStr = cmdWaitbar(frame,nFrames,reverseStr,'inputStr','normalizing movie','waitbarOn',options.waitbarOn,'displayEvery',5);
+				% meanVec = nanmean(thisFrame(:));
+				inputMovie(:,:,frameNo2) = (thisFrame-minVec)./(maxVec-minVec);
+			    reverseStr = cmdWaitbar(frameNo2,nFrames,reverseStr,'inputStr','normalizing movie','waitbarOn',options.waitbarOn,'displayEvery',5);
 			end
 		otherwise
-			display('Input correct option, returning movie...')
+			disp('Input correct option, returning movie...')
 			% inputMovie = NaN;
 			return;
 	end
@@ -146,14 +146,14 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 	end
 	function mijiCheck()
 		if exist('Miji.m','file')==2
-			display(['Miji located in: ' which('Miji.m')]);
+			disp(['Miji located in: ' which('Miji.m')]);
 			% Miji is loaded, continue
 		else
 			pathToMiji = inputdlg('Enter path to Miji.m in Fiji (e.g. \Fiji.app\scripts):',...
 			             'Miji path', [1 100]);
 			pathToMiji = pathToMiji{1};
 			privateLoadBatchFxnsPath = 'private\privateLoadBatchFxns.m';
-			fid = fopen(privateLoadBatchFxnsPath,'at')
+			fid = fopen(privateLoadBatchFxnsPath,'at');
 			fprintf(fid, '\npathtoMiji = ''%s'';\n', pathToMiji);
 			fclose(fid);
 		end
@@ -182,7 +182,7 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		cutoffFilter = [];
 		if padImage==1
 			if options.padImageVersion==2
-				[imX imY] = size(testImage);
+				[imX, imY] = size(testImage);
 				optDim = @(x) 2^ceil(log(x)/log(2));
 				optPadSize = max([optDim(imX) optDim(imY)]);
 				options.padSize = [ceil((optPadSize-imX)/2) ceil((optPadSize-imY)/2)];
@@ -195,13 +195,13 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		end
 		testImageFFT = fft2(testImage);
 		testImageFFT = fftshift(testImageFFT);
-		[imFFTX imFFTY] = size(testImageFFT);
+		[imFFTX, imFFTY] = size(testImageFFT);
 
 		switch bandpassMask
 			case 'gaussian'
 				% implemented using fspecial
 				if lowFreq==0
-					highpassFilter = ones([imFFTX imFFTY]);
+					highpassFilter = ones([imFFTX imFFTY],class(testImage));
 				else
 					highpassFilter = 1-normalizeVector(fspecial('gaussian', [imFFTX imFFTY],lowFreq),'normRange','zeroToOne');
 				end
@@ -220,7 +220,7 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 				end
 			case 'binary'
 				% create binary mask, tried with fspecial but this is easier
-				[ffty fftx] = size(testImageFFT);
+				[ffty, fftx] = size(testImageFFT);
 				cx = round(fftx/2);
 				cy = round(ffty/2);
 				[x,y] = meshgrid(-(cx-1):(fftx-cx),-(cy-1):(ffty-cy));
@@ -239,13 +239,13 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 						% do nothing
 				end
 			otherwise
-				display('invalid option given')
-				filtered_image = inputImage;
+				disp('invalid option given')
+				cutoffFilter = inputImage;
 				return
 		end
 	end
 	function subfxnMedianFilter()
-		display('Running Matlab median filter')
+		disp('Running Matlab median filter')
 		% convert movie to correct class output by fft
 		% outputClass = class(fftImage(squeeze(inputMovie(:,:,1)),'options',ioptions));
 		% inputMovie = cast(inputMovie,outputClass);
@@ -254,14 +254,14 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		manageParallelWorkers('parallel',options.parallel);
 		% ========================
 		%Get dimension information about 3D movie matrix
-		[inputMovieX inputMovieY inputMovieZ] = size(inputMovie);
-		reshapeValue = size(inputMovie);
+		[inputMovieX, inputMovieY, inputMovieZ] = size(inputMovie);
+		% reshapeValue = size(inputMovie);
 		%Convert array to cell array, allows slicing (not contiguous memory block)
 		inputMovie = squeeze(mat2cell(inputMovie,inputMovieX,inputMovieY,ones(1,inputMovieZ)));
 
 		reverseStr = '';
 		nFramesToNormalize = options.maxFrame;
-		try;[percent progress] = parfor_progress(nFramesToNormalize);catch;end; dispStepSize = round(nFramesToNormalize/20); dispstat('','init');
+		% try [percent, progress] = parfor_progress(nFramesToNormalize);catch;end; dispStepSize = round(nFramesToNormalize/20); dispstat('','init');
 		medianFilterNeighborhoodSize = options.medianFilterNeighborhoodSize;
 		medianFilterPadding = options.medianFilterPadding;
         maxFrame = options.maxFrame;
@@ -329,9 +329,9 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		% pairs = [p(:) q(:)];
 
 		% inputImageTest = zeros([size(inputImage,1) size(inputImage,2) nFreqs]);
-		inputImageTest = {};
-		inputMovieDuplicate = {};
-		inputMovieDivide = {};
+		inputImageTest = cell([nFreqs 1]);
+		inputMovieDuplicate = cell([nFreqs 1]);
+		inputMovieDivide = cell([nFreqs 1]);
 		% size(inputImageTest)
 		% Miji(false);
 		% Miji;
@@ -374,9 +374,9 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		% inputMovie = inputImageTestArray;
 	end
 	function subfxnFft()
-		display('Running Matlab FFT')
+		disp('Running Matlab FFT')
 		inputMovie(isnan(inputMovie)) = 0;
-		bandpassMatrix = zeros(size(inputMovie));
+		% bandpassMatrix = zeros(size(inputMovie));
 		% get options
 		ioptions.showImages = options.showImages;
 		ioptions.lowFreq = options.freqLow;
@@ -397,8 +397,8 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		manageParallelWorkers('parallel',options.parallel);
 		% ========================
 		%Get dimension information about 3D movie matrix
-		[inputMovieX inputMovieY inputMovieZ] = size(inputMovie);
-		reshapeValue = size(inputMovie);
+		[inputMovieX, inputMovieY, inputMovieZ] = size(inputMovie);
+		% reshapeValue = size(inputMovie);
 		%Convert array to cell array, allows slicing (not contiguous memory block)
 		inputMovie = squeeze(mat2cell(inputMovie,inputMovieX,inputMovieY,ones(1,inputMovieZ)));
 
@@ -407,7 +407,7 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		% dispstat('','init');
 		% fprintf(1,'FFT movie:  ');
 		nFramesToNormalize = options.maxFrame;
-		try;[percent progress] = parfor_progress(nFramesToNormalize);catch;end; dispStepSize = round(nFramesToNormalize/20); dispstat('','init');
+		% try;[percent progress] = parfor_progress(nFramesToNormalize);catch;end; dispStepSize = round(nFramesToNormalize/20); dispstat('','init');
         secondaryNormalizationType = options.secondaryNormalizationType;
         maxFrame = options.maxFrame;
 		parfor frame=1:nFramesToNormalize
@@ -476,15 +476,16 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		% pairs = [p(:) q(:)];
 
 		% inputImageTest = zeros([size(inputImage,1) size(inputImage,2) nFreqs]);
-		inputImageTest = {};
-		inputMovieDuplicate = {};
-		inputMovieDivide = {};
+		inputImageTest = cell([nFreqs 1]);
+		inputMovieDuplicate = cell([nFreqs 1]);
+		inputMovieDivide = cell([nFreqs 1]);
+        inputMovieDfof = cell([nFreqs 1]);
 		% size(inputImageTest)
 
 
 		startTime = tic;
 		for freqNo = 1:nFreqs
-			display([num2str(freqNo) '/' num2str(nFreqs)])
+			disp([num2str(freqNo) '/' num2str(nFreqs)])
 			lowFreq = lowFreqList(freqNo);
 			highFreq = highFreqList(freqNo);
 			inputMovieFFT = inputMovie;
@@ -584,13 +585,11 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 		end
 	end
 	function subfxnMatlabDisk()
-		display('Matlab fspecial disk background removal')
-
-
+		disp('Matlab fspecial disk background removal')
 
 		%Get dimension information about 3D movie matrix
-		[inputMovieX inputMovieY inputMovieZ] = size(inputMovie);
-		reshapeValue = size(inputMovie);
+		[inputMovieX, inputMovieY, inputMovieZ] = size(inputMovie);
+		% reshapeValue = size(inputMovie);
 		%Convert array to cell array, allows slicing (not contiguous memory block)
 		inputMovie = squeeze(mat2cell(inputMovie,inputMovieX,inputMovieY,ones(1,inputMovieZ)));
 
@@ -667,11 +666,11 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 				return
 		end
 		nFrames = size(inputMovie,3);
-		inputMovieFiltered = zeros(size(inputMovie));
+		inputMovieFiltered = zeros(size(inputMovie),class(inputMovie));
 		reverseStr = '';
 		for frame=1:nFrames
 		    thisFrame = squeeze(inputMovie(:,:,frame));
-		    thisFrame(find(isnan(thisFrame)))=nanmean(thisFrame(:));
+		    thisFrame(isnan(thisFrame))=nanmean(thisFrame(:));
 		    inputMovieFiltered(:,:,frame) = imfilter(thisFrame, movieFilter,options.boundaryType);
 		    reverseStr = cmdWaitbar(frame,nFrames,reverseStr,'inputStr','normalizing movie','waitbarOn',options.waitbarOn,'displayEvery',5);
 		end
@@ -689,11 +688,11 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 				return
 		end
 		nFrames = size(inputMovie,3);
-		inputMovieFiltered = zeros(size(inputMovie));
+		inputMovieFiltered = zeros(size(inputMovie),class(inputMovie));
 		reverseStr = '';
 		for frame=1:nFrames
 		    thisFrame = squeeze(inputMovie(:,:,frame));
-		    thisFrame(find(isnan(thisFrame)))=nanmean(thisFrame(:));
+		    thisFrame(isnan(thisFrame))=nanmean(thisFrame(:));
 		    inputMovieFiltered(:,:,frame) = imfilter(thisFrame, movieFilter,options.boundaryType);
 		    reverseStr = cmdWaitbar(frame,nFrames,reverseStr,'inputStr','normalizing movie','waitbarOn',options.waitbarOn,'displayEvery',5);
 		end

--- a/signal_extraction/cnmfVersionDirLoad.m
+++ b/signal_extraction/cnmfVersionDirLoad.m
@@ -9,6 +9,7 @@ function [success] = cnmfVersionDirLoad(cnmfVersion,varargin)
 
 	% changelog
 		% 2019.01.23 [09:14:54] - Added support for Matlab versions without `contains` function.
+		% 2019.03.03 [20:58:33] - Added removal of cvx from path since they overload `narginchk` which can cause warnings.
 	% TODO
 		%
 
@@ -33,6 +34,7 @@ function [success] = cnmfVersionDirLoad(cnmfVersion,varargin)
 		originalPath = [options.signalExtractionRootPath filesep 'cnmf_original'];
 		currentPath = [options.signalExtractionRootPath filesep 'cnmf_current'];
 		cnmfePath = [options.signalExtractionRootPath filesep 'cnmfe'];
+		cvxPath = [options.signalExtractionRootPath filesep 'cvx_rd'];
 
 		switch cnmfVersion
 			case 'original'
@@ -56,7 +58,7 @@ function [success] = cnmfVersionDirLoad(cnmfVersion,varargin)
 			case 'none'
 				disp('Removing all CNMF dir from path.')
 				% Add and remove necessary CNMF directories from path
-				subfxnRemovePathHere({currentPath,originalPath,cnmfePath},options);
+				subfxnRemovePathHere({currentPath,originalPath,cnmfePath,cvxPath},options);
 			otherwise
 				% do nothing
 		end

--- a/signal_extraction/computeCnmfSignalExtraction_v2.m
+++ b/signal_extraction/computeCnmfSignalExtraction_v2.m
@@ -107,6 +107,9 @@ function [cnmfAnalysisOutput] = computeCnmfSignalExtraction_v2(inputMovie,numExp
     % merge_components.m
     options.merge_thr = 0.85; % Merging threshold (positive between 0  and 1)  0.85
 
+    % imaging frame rate in Hz (defaut: 30)
+    options.fr = 30;
+
     % get options
     options = getOptions(options,varargin);
     % display(options)
@@ -209,6 +212,7 @@ function [cnmfAnalysisOutput] = computeCnmfSignalExtraction_v2(inputMovie,numExp
         'lags',options.lags,...
         'resparse',options.resparse,...
         'fudge_factor',options.fudge_factor,...
+        'fr',options.fr,...
         'merge_thr',options.merge_thr...
         );
     %% Data pre-processing

--- a/signal_processing/computeSignalPeaks.m
+++ b/signal_processing/computeSignalPeaks.m
@@ -69,7 +69,7 @@ function [signalPeaks, signalPeaksArray, signalSigmas] = computeSignalPeaks(sign
     % shift peak detection
     options.nFramesShift = 0;
     % region around each peak to look for a maximum to adjust the test peak by
-    options.peakMaxLook = [-6:6];
+    options.peakMaxLook = -6:6;
     % ===
     % should diff and fast oopsi be done?
     options.addedAnalysis = 0;
@@ -91,14 +91,15 @@ function [signalPeaks, signalPeaksArray, signalSigmas] = computeSignalPeaks(sign
     %========================
     try
         % make sure matrix is double
-        if ~strcmp(class(signalMatrix),'double')
+        % if ~strcmp(class(signalMatrix),'double')
+        if ~isa(signalMatrix,'double')
             if options.outputInfo==1
-                display('converting signalMatrix to double');
+                disp('converting signalMatrix to double');
             end
             signalMatrix = double(signalMatrix);
         end
         if options.outputInfo==1
-            display('calculating signal peaks...')
+            disp('calculating signal peaks...')
         end
         nSignals = size(signalMatrix,1);
         % this matrix will contain binarized version of signalMatrix
@@ -108,20 +109,34 @@ function [signalPeaks, signalPeaksArray, signalSigmas] = computeSignalPeaks(sign
         % open waitbar
         % if options.waitbarOn==1 waitbarHandle = waitbar(0, 'detecting traces...'); end
         % loop over all signals.
-        reverseStr = '';
+        % reverseStr = '';
         manageParallelWorkers('parallel',options.parallel);
         signalPeaksArrayTmp = cell([1 nSignals]);
         signalSigmas = [];
         % try;[percent progress] = parfor_progress(nSignals);catch;end; dispStepSize = round(nSignals/20); dispstat('','init');
 
+        % Convert to cell array to reduce memory transfer during parallelization
+        signalMatrix = squeeze(mat2cell(signalMatrix,ones(1,size(signalMatrix,1)),size(signalMatrix,2)));
+
         [optionsOut] = computePeakForSignalOptions('options', options);
 
-        parfor signalNum=1:nSignals
+        % Only implement in Matlab 2017a and above
+        if ~verLessThan('matlab', '9.2')
+            D = parallel.pool.DataQueue;
+            afterEach(D, @nUpdateParforProgress);
+            p = 1;
+            N = nSignals;
+            nInterval = 25;
+            options_waitbarOn = options.waitbarOn;
+        end
+
+        parfor signalNum = 1:nSignals
             optionsOutCopy = optionsOut;
             optionsCopy = options;
             % [percent progress] = parfor_progress;if mod(progress,dispStepSize) == 0;dispstat(sprintf('progress %0.1f %',percent));else;end
             % get the current signal and find its peaks
-            thisSignal = signalMatrix(signalNum,:);
+            % thisSignal = signalMatrix(signalNum,:);
+            thisSignal = signalMatrix{signalNum};
             %
             signalSigmas(signalNum) = std(thisSignal);
             signalPeaksArray{signalNum} = computePeakForSignal(thisSignal,optionsOutCopy);
@@ -137,10 +152,10 @@ function [signalPeaks, signalPeaksArray, signalSigmas] = computeSignalPeaks(sign
                 [~] = viewComputePeaksPlot(thisSignal,signalPeaksArrayTmp{signalNum},[0 0 1],options.makePlots,20,0.1,'off',options)
                 legend('signal','raw','signal','diff')
                 title(['raw: ' num2str(length(signalPeaksArray{signalNum})) ' | diff: ' num2str(length(signalPeaksArrayTmp{signalNum}))]);
-                [x,y,reply]=ginput(1);
+                [~,~,~]=ginput(1);
                 % fast oopsi
                 [Nhat] = computePeakForSignalOopsi(thisSignal,signalPeaksArray{signalNum},options);
-                [x,y,reply]=ginput(1);
+                [~,~,~]=ginput(1);
                 % ===
             end
             % create matrix of peaks
@@ -148,10 +163,16 @@ function [signalPeaks, signalPeaksArray, signalSigmas] = computeSignalPeaks(sign
 
             % waitbar access
             % reverseStr = cmdWaitbar(signalNum,nSignals,reverseStr,'inputStr','detecting peaks','waitbarOn',options.waitbarOn,'displayEvery',50);
+
+            if ~verLessThan('matlab', '9.2')
+                % Update
+                send(D, signalNum);
+            end
         end
         if options.makePlots==1
             for signalNum=1:nSignals
-                thisSignal = signalMatrix(signalNum,:);
+                % thisSignal = signalMatrix(signalNum,:);
+                thisSignal = signalMatrix{signalNum};
                     [~] = viewComputePeaksPlot(thisSignal,signalPeaksArray{signalNum},[0 0 0],options.makePlots,50,2,'on',options,signalNum,nSignals,options.numStdsForThresh);
                     pause
                     keyIn = get(gcf,'CurrentCharacter');
@@ -183,6 +204,20 @@ function [signalPeaks, signalPeaksArray, signalSigmas] = computeSignalPeaks(sign
         disp(getReport(err,'extended','hyperlinks','on'));
         display(repmat('@',1,7))
     end
+    function nUpdateParforProgress(~)
+        if ~verLessThan('matlab', '9.2')
+            p = p + 1;
+            if (mod(p,nInterval)==0||p==2||p==nSignals)&&options_waitbarOn==1
+                if p==nSignals
+                    fprintf('%d%%\n',round(p/nSignals*100))
+                else
+                    fprintf('%d%% | ',round(p/nSignals*100))
+                end
+                % cmdWaitbar(p,nSignals,'','inputStr','','waitbarOn',1);
+            end
+            % [p mod(p,nInterval)==0 (mod(p,nInterval)==0||p==nSignals)&&options_waitbarOn==1]
+        end
+    end
 end
 function [inputSignal] = viewComputePeaksPlot(inputSignal,testpeaks,dotColor,makePlots,markersize,linewidth,holdVal,options,signalNum,nSignals,numStdsForThresh)
     % decide whether to plot the peaks with points indicating location of
@@ -213,7 +248,7 @@ function [inputSignal] = viewComputePeaksPlot(inputSignal,testpeaks,dotColor,mak
 
         subplot(4,3,3)
             peakSignalAmplitude = inputSignal(testpeaks(:));
-            [peakSignalAmplitude peakIdx] = sort(spikeCenterTrace(:,round(end/2)+1),'descend');
+            [peakSignalAmplitude, peakIdx] = sort(spikeCenterTrace(:,round(end/2)+1),'descend');
             spikeCenterTrace = spikeCenterTrace(peakIdx,:);
             if size(spikeCenterTrace,1)>20
                 spikeCenterTrace = spikeCenterTrace(1:20,:);

--- a/video/getObjCutMovie.m
+++ b/video/getObjCutMovie.m
@@ -193,10 +193,11 @@ function [k] = getObjCutMovie(inputMovie,inputImages,varargin)
 			k{signalNo}(cHairY,cHairX,:) = NaN;
 			switch options.extendedCrosshairs
 				case 1
-					k{signalNo}(cHairY-1,cHairX,:) = k{signalNo}(cHairY-1,cHairX,:)+options.crossHairVal;
-					k{signalNo}(cHairY+1,cHairX,:) = k{signalNo}(cHairY+1,cHairX,:)+options.crossHairVal;
-					k{signalNo}(cHairY,cHairX-1,:) = k{signalNo}(cHairY,cHairX-1,:)+options.crossHairVal;
-					k{signalNo}(cHairY,cHairX+1,:) = k{signalNo}(cHairY,cHairX+1,:)+options.crossHairVal;
+					tmpV1 = cast(options.crossHairVal,class(k{1}));
+					k{signalNo}(cHairY-1,cHairX,:) = k{signalNo}(cHairY-1,cHairX,:)+tmpV1;
+					k{signalNo}(cHairY+1,cHairX,:) = k{signalNo}(cHairY+1,cHairX,:)+tmpV1;
+					k{signalNo}(cHairY,cHairX-1,:) = k{signalNo}(cHairY,cHairX-1,:)+tmpV1;
+					k{signalNo}(cHairY,cHairX+1,:) = k{signalNo}(cHairY,cHairX+1,:)+tmpV1;
 				case 2
 					% idxY=1:size(k{signalNo},1);
 					% idxX=1:size(k{signalNo},2);
@@ -210,8 +211,9 @@ function [k] = getObjCutMovie(inputMovie,inputImages,varargin)
 
 					% k{signalNo}(:,cHairX,:) = k{signalNo}(:,cHairX,:)+options.crossHairVal;
 					% k{signalNo}(cHairY,:,:) = k{signalNo}(cHairY,:,:)+options.crossHairVal;
-					k{signalNo}(idxY,cHairX,:) = k{signalNo}(idxY,cHairX,:)+options.crossHairVal;
-					k{signalNo}(cHairY,idxX,:) = k{signalNo}(cHairY,idxX,:)+options.crossHairVal;
+					tmpV1 = cast(options.crossHairVal,class(k{1}));
+					k{signalNo}(idxY,cHairX,:) = k{signalNo}(idxY,cHairX,:)+tmpV1;
+					k{signalNo}(cHairY,idxX,:) = k{signalNo}(cHairY,idxX,:)+tmpV1;
 				otherwise
 					% body
 			end

--- a/view/cmdWaitbar.m
+++ b/view/cmdWaitbar.m
@@ -13,7 +13,7 @@ function [reverseStr] = cmdWaitbar(i,nItems,reverseStr,varargin)
 	% changelog
 			% 2014.02.14 [16:35:55] now is mostly
 	% TODO
-			% Should reverseStr be made global so function is entirely self-contained?
+			% Should reverseStr be made global so function is entirely self-contained? - NO, globals are evil.
 			% change so waitbarOn = 0 can short circuit getOptions to save speed execution time
 	% example
 		% before loop = reverseStr
@@ -41,12 +41,21 @@ function [reverseStr] = cmdWaitbar(i,nItems,reverseStr,varargin)
 		else
 			% diary OFF
 		end
-		txt=sprintf(': %1.2f',i/nItems*100);
+		if usejava('desktop')==0
+		    % return;
+		    reverseStr = '';
+			txt=sprintf(': %1.2f | ',i/nItems*100);
+		else
+			txt=sprintf(': %1.2f',i/nItems*100);
+		end
 		% txt=strcat('\n',options.inputStr,txt,'%%');
 		txt=strcat('',options.inputStr,txt,'%%');
 		fprintf([reverseStr, txt]);
 		% drawnow;
 	   	reverseStr = repmat(sprintf('\b'), 1, length(txt)-1);
+	   	if usejava('desktop')==0
+		    reverseStr = '';
+	   	end
 	end
 	if i==nItems
 		fprintf('\n');
@@ -77,3 +86,4 @@ function [reverseStr] = cmdWaitbar(i,nItems,reverseStr,varargin)
 		% end
 	% end
 	% disp('done');
+end

--- a/view/compareSignalToMovie.m
+++ b/view/compareSignalToMovie.m
@@ -173,6 +173,9 @@ function [croppedPeakImages] = compareSignalToMovie(inputMovie, inputImages, inp
 			croppedPeakImages = inputMovie(yLow:yHigh,xLow:xHigh,peakLocations);
 		end
 
+		% Insure that the peak images are the same class as the input images for calculation purposes
+		croppedPeakImages = cast(croppedPeakImages,class(inputImages));
+
 		firstImg = squeeze(inputImages(yLow:yHigh,xLow:xHigh,signalNo));
 
 		if options.addPadding==1&(xDiff~=0|yDiff~=0)

--- a/view/compareSignalToMovie.m
+++ b/view/compareSignalToMovie.m
@@ -226,10 +226,11 @@ function [croppedPeakImages] = compareSignalToMovie(inputMovie, inputImages, inp
 			croppedPeakImages(cHairY,cHairX,:) = NaN;
 			switch options.extendedCrosshairs
 				case 1
-					croppedPeakImages(cHairY-1,cHairX,:) = croppedPeakImages(cHairY-1,cHairX,:)+options.crossHairVal;
-					croppedPeakImages(cHairY+1,cHairX,:) = croppedPeakImages(cHairY+1,cHairX,:)+options.crossHairVal;
-					croppedPeakImages(cHairY,cHairX-1,:) = croppedPeakImages(cHairY,cHairX-1,:)+options.crossHairVal;
-					croppedPeakImages(cHairY,cHairX+1,:) = croppedPeakImages(cHairY,cHairX+1,:)+options.crossHairVal;
+					tmpV1 = cast(options.crossHairVal,class(croppedPeakImages));
+					croppedPeakImages(cHairY-1,cHairX,:) = croppedPeakImages(cHairY-1,cHairX,:)+tmpV1;
+					croppedPeakImages(cHairY+1,cHairX,:) = croppedPeakImages(cHairY+1,cHairX,:)+tmpV1;
+					croppedPeakImages(cHairY,cHairX-1,:) = croppedPeakImages(cHairY,cHairX-1,:)+tmpV1;
+					croppedPeakImages(cHairY,cHairX+1,:) = croppedPeakImages(cHairY,cHairX+1,:)+tmpV1;
 				case 2
 					xS = size(croppedPeakImages,2);
 					yS = size(croppedPeakImages,1);
@@ -240,9 +241,9 @@ function [croppedPeakImages] = compareSignalToMovie(inputMovie, inputImages, inp
 					% idxX=1:size(croppedPeakImages,2);
 					% idxY = setdiff(idxY,round(0.25*length(idxY)):round(0.75*length(idxY)));
 					% idxX = setdiff(idxX,round(0.25*length(idxX)):round(0.75*length(idxX)));
-
-					croppedPeakImages(idxY,cHairX,:) = croppedPeakImages(idxY,cHairX,:)+options.crossHairVal;
-					croppedPeakImages(cHairY,idxX,:) = croppedPeakImages(cHairY,idxX,:)+options.crossHairVal;
+					tmpV1 = cast(options.crossHairVal,class(croppedPeakImages));
+					croppedPeakImages(idxY,cHairX,:) = croppedPeakImages(idxY,cHairX,:)+tmpV1;
+					croppedPeakImages(cHairY,idxX,:) = croppedPeakImages(cHairY,idxX,:)+tmpV1;
 				otherwise
 					% body
 			end

--- a/view/plotSignalsGraph.m
+++ b/view/plotSignalsGraph.m
@@ -36,11 +36,20 @@ function plotSignalsGraph(IcaTraces,varargin)
     originalAxisColorOrder = get(groot,'defaultAxesColorOrder');
     switch options.newAxisColorOrder
         case 'gray'
-            c1 = gray(nSignals);
+            c1 = gray(nSignals*2);
             c1=c1(1:round(end/2),:);
         case 'red'
-            c1 = customColormap({[1 0.5 0.5],[1 0 0]},'nPoints',nSignals);
-            c1 = c1(randperm(size(c1,1)),:);
+            c1 = customColormap({[1 0.5 0.5],[1 0 0]},'nPoints',nSignals*2);
+            c1=c1(round(linspace(1,nSignals*2,nSignals)),:);
+            % c1 = c1(randperm(size(c1,1)),:);
+        case 'green'
+            c1 = customColormap({[0.5 1 0.5]/1.5,[0 1 0]/2},'nPoints',nSignals*2);
+            c1=c1(round(linspace(1,nSignals*2,nSignals)),:);
+            % c1 = c1(randperm(size(c1,1)),:);
+        case 'blue'
+            c1 = customColormap({[0.5 0.5 1],[0 0 1]},'nPoints',nSignals*2);
+            c1=c1(round(linspace(1,nSignals*2,nSignals)),:);
+            % c1 = c1(randperm(size(c1,1)),:);
         otherwise
             c1 = [];
     end


### PR DESCRIPTION
- Improved `signalSorter.m` to add support for large movies that can't be loaded into RAM.
- HDF5 files should be chunked when saved to improve read speed (see `writeHDF5Data` or `createHdf5File`).
- Changes to allow `readHDF5Subset` to efficiently read requests for individual frames or [x y z] movie chunks that contain overlapping or duplicate segments (as is the case when using `signalSorter`).
- See comments for details on use.