### PR TITLE
CNMF-E setting long file/folder names update

### DIFF
--- a/@calciumImagingAnalysis/calciumImagingAnalysis.m
+++ b/@calciumImagingAnalysis/calciumImagingAnalysis.m
@@ -83,6 +83,8 @@ classdef calciumImagingAnalysis < dynamicprops
 		hdf5Datasetname = '/1';
 		% type of images to save analysis as '-dpng','-dmeta','-depsc2'
 		imgSaveTypes = {'-dpng'};
+		% Custom subject regexp find string to pass to getFileInfo
+		subjectRegexp = '(m|M|f|F|Mouse|mouse|Mouse_|mouse_)\d+';
 		% colormap to be used
 		% colormap = customColormap([]);
 		% colormap = customColormap({[0 0 0.7],[1 1 1],[0.7 0 0]});

--- a/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
+++ b/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
@@ -737,7 +737,6 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
                         end
                         newSettings = ['private' filesep 'settings' filesep newFile '.m'];
 
-						newSettings = ['private' filesep 'settings' filesep 'cnmfeSettings_' timeStr '_' foldername '.m'];
 						copyfile(['settings' filesep 'cnmfeSettings.m'],newSettings);
 						h1 = matlab.desktop.editor.openDocument([pwd filesep newSettings]);
 						disp(['Close ' newFile '.m file in Editor to continue!'])

--- a/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
+++ b/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
@@ -729,10 +729,18 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 						[~,foldername,~] = fileparts(obj.inputFolders{obj.fileNum});
 						timeStr = datestr(now,'yyyymmdd_HHMMSS','local');
 
+						% Truncate to deal with MATLAB limit
+						newFile = ['cnmfeSettings_' timeStr '_' foldername];
+						if (length(newFile )+2)>namelengthmax
+							newFile = newFile(1:namelengthmax-2);
+                            disp('Truncating filename to comply with maximum file length limits in MATLAB');
+                        end
+                        newSettings = ['private' filesep 'settings' filesep newFile '.m'];
+
 						newSettings = ['private' filesep 'settings' filesep 'cnmfeSettings_' timeStr '_' foldername '.m'];
 						copyfile(['settings' filesep 'cnmfeSettings.m'],newSettings);
 						h1 = matlab.desktop.editor.openDocument([pwd filesep newSettings]);
-						disp(['Close ' 'cnmfeSettings_' timeStr '_' foldername '.m file in Editor to continue!'])
+						disp(['Close ' newFile '.m file in Editor to continue!'])
 						% pause while user edits
 						while h1.Opened==1;end
 						h1.close
@@ -750,12 +758,14 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 						timeStr = datestr(now,'yyyymmdd_HHMMSS','local');
 						[~,fileNameH,extH] = fileparts([folderPath filePath]);
 
-						% 'cnmfeSettings_'
+						% Truncate to deal with MATLAB limit
 						newFile = [fileNameH '_' timeStr '_' foldername];
 						if (length(newFile)+2)>namelengthmax
 							newFile = newFile(1:namelengthmax-2);
+							disp('Truncating filename to comply with maximum file length limits in MATLAB');
 						end
 						newSettings = ['private' filesep 'settings' filesep newFile '.m'];
+
 						copyfile([folderPath filesep filePath],newSettings);
 						h1 = matlab.desktop.editor.openDocument([pwd filesep newSettings]);
 						disp(['Close ' newFile '.m file in Editor to continue!'])

--- a/@calciumImagingAnalysis/modelGetFileInfo.m
+++ b/@calciumImagingAnalysis/modelGetFileInfo.m
@@ -13,7 +13,7 @@ function obj = modelGetFileInfo(obj)
 		%
 	obj.inputFolders = obj.dataPath;
 	for i=1:length(obj.dataPath)
-	    fileInfo = getFileInfo(obj.dataPath{i});
+	    fileInfo = getFileInfo(obj.dataPath{i},'subjectRegexp',obj.subjectRegexp);
 	    % fileInfo
 	    obj.subjectStr{i} = fileInfo.subject;
 	    obj.subjectNum{i} = fileInfo.subjectNum;

--- a/@calciumImagingAnalysis/viewObjmaps.m
+++ b/@calciumImagingAnalysis/viewObjmaps.m
@@ -129,7 +129,8 @@ function obj = viewObjmaps(obj,varargin)
 
 	for thisFileNumIdx = 1:nFilesToAnalyze
 		[~,~] = openFigure(45+thisFileNumIdx, '');
-
+	end
+	for thisFileNumIdx = 1:nFilesToAnalyze
 		[~,~] = openFigure(2000+thisFileNumIdx, '');
 	end
 	% [figHandle figNo] = openFigure(969, '');
@@ -223,7 +224,12 @@ function obj = viewObjmaps(obj,varargin)
 			subfxnDisplayMovie();
 
 			subplotTmp(rowSubP,colSubP,[3 4 7 8])
-				plotSignalsGraph(inputSignals(logical(valid),:),'newAxisColorOrder','default')
+				if isempty(nSignalsShow)
+					plotSignalsGraph(inputSignals(logical(valid),:),'newAxisColorOrder','default');
+				else
+					inputSignalsTmp = inputSignals(logical(valid),:);
+					plotSignalsGraph(inputSignalsTmp(1:nSignalsShow),'newAxisColorOrder','default');
+				end
 				axis tight
 				title('Cell activity traces')
 

--- a/@calciumImagingAnalysis/viewObjmaps.m
+++ b/@calciumImagingAnalysis/viewObjmaps.m
@@ -228,7 +228,7 @@ function obj = viewObjmaps(obj,varargin)
 					plotSignalsGraph(inputSignals(logical(valid),:),'newAxisColorOrder','default');
 				else
 					inputSignalsTmp = inputSignals(logical(valid),:);
-					plotSignalsGraph(inputSignalsTmp(1:nSignalsShow),'newAxisColorOrder','default');
+					plotSignalsGraph(inputSignalsTmp(1:nSignalsShow,:),'newAxisColorOrder','default');
 				end
 				axis tight
 				title('Cell activity traces')

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ Repository notes:
 - [Removing cells not within brain region with  `modelModifyRegionAnalysis`](#removing-cells-not-within-brain-region-with-modelmodifyregionanalysis)
 - [Cross-session cell alignment with  `computeMatchObjBtwnTrials`](#cross-session-cell-alignment-with-computematchobjbtwntrials)
 - [ImageJ+MATLAB based mouse location tracking](#imagejmatlab-based-mouse-location-tracking)
+- [Acknowledgments](#acknowledgments)
 - [References](#references)
 - [Questions](#questions)
+- [License](#license)
 
 ***
 

--- a/hdf5/downsampleHdf5Movie.m
+++ b/hdf5/downsampleHdf5Movie.m
@@ -39,6 +39,8 @@ function [success] = downsampleHdf5Movie(inputFilePath, varargin)
 	options.newFilenameTwo = [pathstr filesep 'concat_' name '.h5'];
 	% Int: Defines gzip compression level (0-9). 0 = no compression, 9 = most compression.
  	options.deflateLevel = 1;
+ 	% Int: chunk size in [x y z] of the dataset, leave empty for auto chunking
+ 	options.dataDimsChunkCopy = [128 128 1];
 	% get options
 	options = getOptions(options,varargin);
 	% unpack options into current workspace
@@ -97,7 +99,7 @@ function [success] = downsampleHdf5Movie(inputFilePath, varargin)
 
 			% save the movie
 			if currentSubset==1
-				createHdf5File(options.newFilename, options.outputDatasetName, inputMovie,'deflateLevel',options.deflateLevel);
+				createHdf5File(options.newFilename, options.outputDatasetName, inputMovie,'deflateLevel',options.deflateLevel,'dataDimsChunkCopy',options.dataDimsChunkCopy);
 			else
 				appendDataToHdf5(options.newFilename, options.outputDatasetName, inputMovie);
 			end
@@ -111,7 +113,7 @@ function [success] = downsampleHdf5Movie(inputFilePath, varargin)
 				downsampleMovieNested('downsampleDimension', 'space','downsampleFactor',options.downsampleFactorTwo,'waitbarInterval',options.waitbarInterval);
 				% save the movie
 				if currentSubset==1
-					createHdf5File(options.newFilenameTwo, options.outputDatasetName, inputMovie,'deflateLevel',options.deflateLevel);
+					createHdf5File(options.newFilenameTwo, options.outputDatasetName, inputMovie,'deflateLevel',options.deflateLevel,'dataDimsChunkCopy',options.dataDimsChunkCopy);
 				else
 					appendDataToHdf5(options.newFilenameTwo, options.outputDatasetName, inputMovie);
 				end

--- a/settings/cnmfeSettings.m
+++ b/settings/cnmfeSettings.m
@@ -6,11 +6,11 @@
 % ========================
 % OVERALL
 % turn on parallel
-options.nonCNMF.parallel = 1;
+cnmfeOpts.nonCNMF.parallel = 1;
 % Binary: 1 = run merging algorithms
-options.runMerge = 1;
+cnmfeOpts.runMerge = 1;
 % Binary: 1 = remove false positives using CNMF-E algorithm
-options.runRemoveFalsePositives = 1;
+cnmfeOpts.runRemoveFalsePositives = 1;
 % ===COMPUTATION
 % Float: GB, memory space you allow to use in MATLAB
 cnmfeOpts.memory_size_to_use = 32; %


### PR DESCRIPTION
- MATLAB has a 63 character limit for script names, truncating cnmfe setting names over this limit to comply.
- Add in the name of the original settings file used in a 1st line comment instead of in the filename to cause less trucation of folder name.