### PR TITLE
Cross-session cell alignment, signalSorter, and misc updates

### DIFF
--- a/@calciumImagingAnalysis/calciumImagingAnalysis.m
+++ b/@calciumImagingAnalysis/calciumImagingAnalysis.m
@@ -26,7 +26,7 @@ classdef calciumImagingAnalysis < dynamicprops
 		MICRON_PER_PIXEL =  2.51; % 2.37;
 
 		defaultObjDir = pwd;
-		classVersion = 'v3.20190420';
+		classVersion = 'v3.2.1-20190428';
 		serverPath = '';
 		privateSettingsPath = ['private' filesep 'settings' filesep 'privateLoadBatchFxns.m'];
 		% place where functions can temporarily story user settings
@@ -555,6 +555,7 @@ classdef calciumImagingAnalysis < dynamicprops
 		obj = modelDownsampleRawMovies(obj)
 		obj = modelBatchCopyFiles(obj)
 		obj = modelLoadSaveData(obj)
+		obj = modelSaveMatchObjBtwnTrials(obj,varargin)
 
 		% helps clean and load tracking data
 		obj = modelTrackingData(obj)
@@ -869,12 +870,14 @@ classdef calciumImagingAnalysis < dynamicprops
 			obj.dataSavePath = ['private' filesep 'data' filesep datestr(now,'yyyymmdd','local') filesep];
 			obj.logSavePath = ['private' filesep 'logs' filesep datestr(now,'yyyymmdd','local') filesep];
 			obj.settingsSavePath = ['private' filesep 'settings'];
+			obj.videoSaveDir = ['private' filesep 'vids' filesep datestr(now,'yyyymmdd','local') filesep];
 
 			% ensure private folders are set
-			if ~exist(obj.picsSavePath,'dir');mkdir(obj.picsSavePath);end
-			if ~exist(obj.dataSavePath,'dir');mkdir(obj.dataSavePath);end
-			if ~exist(obj.logSavePath,'dir');mkdir(obj.logSavePath);end
+			if ~exist(obj.picsSavePath,'dir');mkdir(obj.picsSavePath);fprintf('Creating directory: %s\n',obj.picsSavePath);end
+			if ~exist(obj.dataSavePath,'dir');mkdir(obj.dataSavePath);fprintf('Creating directory: %s\n',obj.dataSavePath);end
+			if ~exist(obj.logSavePath,'dir');mkdir(obj.logSavePath);fprintf('Creating directory: %s\n',obj.logSavePath);end
 			if ~exist(obj.settingsSavePath,'dir');mkdir(obj.settingsSavePath);fprintf('Creating directory: %s\n',obj.settingsSavePath);end
+			if ~exist(obj.videoSaveDir,'dir');mkdir(obj.videoSaveDir);fprintf('Creating directory: %s\n',obj.videoSaveDir);end
 
 			% load user specific settings
 			loadUserSettings = ['private' filesep 'settings' filesep 'calciumImagingAnalysisInitialize.m'];
@@ -996,6 +999,7 @@ classdef calciumImagingAnalysis < dynamicprops
 			'viewSubjectMovieFrames',
 			'computeMatchObjBtwnTrials',
 			'viewMatchObjBtwnSessions',
+			'modelSaveMatchObjBtwnTrials',
 			'computeCellDistances',
 			'computeCrossDayDistancesAlignment'
 			};

--- a/@calciumImagingAnalysis/calciumImagingAnalysis.m
+++ b/@calciumImagingAnalysis/calciumImagingAnalysis.m
@@ -26,7 +26,7 @@ classdef calciumImagingAnalysis < dynamicprops
 		MICRON_PER_PIXEL =  2.51; % 2.37;
 
 		defaultObjDir = pwd;
-		classVersion = 'v3.20190414';
+		classVersion = 'v3.20190420';
 		serverPath = '';
 		privateSettingsPath = ['private' filesep 'settings' filesep 'privateLoadBatchFxns.m'];
 		% place where functions can temporarily story user settings
@@ -247,6 +247,8 @@ classdef calciumImagingAnalysis < dynamicprops
 		% signal related
 		% either the raw signals (traces) or
 		rawSignals = {};
+		% secondary either the raw signals (traces) or
+		rawSignals2 = {};
 		%
 		rawImages = {};
 		% computed signal peaks/locations, to reduce computation in functions
@@ -302,6 +304,7 @@ classdef calciumImagingAnalysis < dynamicprops
 		folderBaseSaveStr = {};
 		folderBasePlaneSaveStr = {};
 		folderBaseDisplayStr = {};
+		folderBaseSaveStrUnique = {};
 
 		% path to CSV/TAB file or matlab table containing trial information and frames when stimuli occur
 		discreteStimulusTable = {};
@@ -557,7 +560,7 @@ classdef calciumImagingAnalysis < dynamicprops
 		obj = modelTrackingData(obj)
 
 		% helper
-		[inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, validType] = modelGetSignalsImages(obj,varargin)
+		[inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, validType, inputSignals2] = modelGetSignalsImages(obj,varargin)
 		[fileIdxArray, idNumIdxArray, nFilesToAnalyze, nFiles] = getAnalysisSubsetsToAnalyze(obj)
 		[turboregSettingStruct] = getRegistrationSettings(obj,inputTitleStr)
 

--- a/@calciumImagingAnalysis/computeManualSortSignals.m
+++ b/@calciumImagingAnalysis/computeManualSortSignals.m
@@ -91,7 +91,7 @@ function obj = computeManualSortSignals(obj)
 			end
 
 			try
-				[rawSignals rawImages signalPeaks signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw');
+				[rawSignals rawImages signalPeaks signalPeaksArray, ~, ~, rawSignals2] = modelGetSignalsImages(obj,'returnType','raw');
 				skipReload = 1;
 			catch
 				obj.guiEnabled = 0;
@@ -139,11 +139,14 @@ function obj = computeManualSortSignals(obj)
 				valid = validClassifier;
 			end
 
+			if skipReload==0
+				[rawSignals, rawImages, signalPeaks, signalPeaksArray, ~, ~, rawSignals2] = modelGetSignalsImages(obj,'returnType','raw');
+			end
 			switch usrIdxChoiceSignalType
 				case 'PCAICA'
-					if skipReload==0
-						[rawSignals rawImages signalPeaks signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw');
-					end
+					% if skipReload==0
+					% 	[rawSignals rawImages signalPeaks signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw');
+					% end
 					% check if the folder has temporary decisions to load (e.g. if a crash occured)
 					if usrIdxChoiceAutoValid==3
 						previousDecisionList = getFileList(currentFolderPath, strrep(options.cleanedICdecisionsSaveStr,'.mat',''));
@@ -156,9 +159,9 @@ function obj = computeManualSortSignals(obj)
 					ioptions.minValConstant = -0.02;
 					ioptions.threshold = 0.5;
 				case 'EM'
-					if skipReload==0
-						[rawSignals, rawImages, signalPeaks, signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw_CellMax');
-					end
+					% if skipReload==0
+					% 	[rawSignals, rawImages, signalPeaks, signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw_CellMax');
+					% end
 					if usrIdxChoiceAutoValid==3
 						previousDecisionList = getFileList(currentFolderPath, strrep(options.emSaveSorted,'.mat',''));
 						if ~isempty(previousDecisionList)
@@ -170,9 +173,9 @@ function obj = computeManualSortSignals(obj)
 					ioptions.minValConstant = -400;
 					ioptions.threshold = 0.5;
 				case 'EXTRACT'
-					if skipReload==0
-						[rawSignals, rawImages, signalPeaks, signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw');
-					end
+					% if skipReload==0
+					% 	[rawSignals, rawImages, signalPeaks, signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw');
+					% end
 					if usrIdxChoiceAutoValid==3
 						previousDecisionList = getFileList(currentFolderPath, strrep(obj.sortedEXTRACTStructSaveStr,'.mat',''));
 						if ~isempty(previousDecisionList)
@@ -185,9 +188,9 @@ function obj = computeManualSortSignals(obj)
 					ioptions.minValConstant = -10;
 					ioptions.threshold = 0.5;
 				case 'CNMF'
-					if skipReload==0
-						[rawSignals, rawImages, signalPeaks, signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw');
-					end
+					% if skipReload==0
+					% 	[rawSignals, rawImages, signalPeaks, signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw');
+					% end
 					if usrIdxChoiceAutoValid==3
 						previousDecisionList = getFileList(currentFolderPath, strrep(obj.sortedCNMFStructSaveStr,'.mat',''));
 						if ~isempty(previousDecisionList)
@@ -200,9 +203,9 @@ function obj = computeManualSortSignals(obj)
 					ioptions.minValConstant = -200;
 					ioptions.threshold = 0.3;
 				case 'CNMFE'
-					if skipReload==0
-						[rawSignals, rawImages, signalPeaks, signalPeaksArray] = modelGetSignalsImages(obj,'returnType','raw');
-					end
+					% if skipReload==0
+					% 	[rawSignals, rawImages, signalPeaks, signalPeaksArray, ~, ~, rawSignals2] = modelGetSignalsImages(obj,'returnType','raw');
+					% end
 					if usrIdxChoiceAutoValid==3
 						previousDecisionList = getFileList(currentFolderPath, strrep(obj.extractionMethodSortedSaveStr.(obj.signalExtractionMethod),'.mat',''));
 						if ~isempty(previousDecisionList)
@@ -271,6 +274,8 @@ function obj = computeManualSortSignals(obj)
 			ioptions.coord.xCoords = max(1,round(obj.objLocations{fileNum}.(obj.signalExtractionMethod)(:,1)));
 			ioptions.coord.yCoords = max(1,round(obj.objLocations{fileNum}.(obj.signalExtractionMethod)(:,2)));
 
+			ioptions.inputSignalsSecond = rawSignals2;
+
 			ioptions.preComputeImageCutMovies = userIdxPreComputeImageCutMovies;
 			% ioptions.classifierFilepath = options.classifierFilepath;
 			% ioptions.classifierType = options.classifierType;
@@ -278,9 +283,11 @@ function obj = computeManualSortSignals(obj)
 			if userIdxOnlyResortGoodSources==1&usrIdxChoiceAutoValid==3
 				newValid = logical(valid);
 				rawImages = rawImages(:,:,newValid);
-				rawSignals =rawSignals(newValid,:);
+				rawSignals = rawSignals(newValid,:);
+				rawSignals2 = rawSignals2(newValid,:);
 				ioptions.signalPeaks = ioptions.signalPeaks(newValid,:);
 				ioptions.signalPeaksArray = ioptions.signalPeaksArray(newValid);
+				ioptions.inputSignalsSecond = rawSignals2;
 				ioptions.valid = ioptions.valid(newValid);
 				ioptions.coord.xCoords = ioptions.coord.xCoords(newValid);
 				ioptions.coord.yCoords = ioptions.coord.yCoords(newValid);

--- a/@calciumImagingAnalysis/computeMatchObjBtwnTrials.m
+++ b/@calciumImagingAnalysis/computeMatchObjBtwnTrials.m
@@ -173,7 +173,8 @@ function obj = computeMatchObjBtwnTrials(obj)
 		validFoldersIdx
 		validFoldersIdx = validFoldersIdx([trialIDsTmp{:}]);
 		validFoldersIdx
-		globalAssayStr = obj.folderBaseSaveStr(validFoldersIdx);
+		% globalAssayStr = obj.folderBaseSaveStr(validFoldersIdx);
+		globalAssayStr = obj.folderBaseSaveStrUnique(validFoldersIdx);
 		obj.globalIDFolders.(thisSubjectStr) = globalAssayStr;
 	end
 end

--- a/@calciumImagingAnalysis/modelGetFileInfo.m
+++ b/@calciumImagingAnalysis/modelGetFileInfo.m
@@ -30,5 +30,8 @@ function obj = modelGetFileInfo(obj)
 	    obj.folderBaseSaveStr{i} = strcat(fileInfo.date,'_',fileInfo.protocol,'_',fileInfo.subject,'_',fileInfo.assay);
 	    obj.folderBasePlaneSaveStr{i} = strcat(fileInfo.date,'_',fileInfo.protocol,'_',fileInfo.subject,'_',fileInfo.assay,'_',fileInfo.imagingPlane);
 	    obj.folderBaseDisplayStr{i} = strrep(obj.folderBaseSaveStr{i},'_',' ');
+
+	    obj.folderBaseSaveStrUnique{i} = strcat(fileInfo.date,'_',fileInfo.protocol,'_',fileInfo.subject,'_',fileInfo.assay,'_',datestr(now,'yyyymmdd_HHMMSSFFF','local'));
+	    pause(0.001)
 	end
 end

--- a/@calciumImagingAnalysis/modelGetSignalsImages.m
+++ b/@calciumImagingAnalysis/modelGetSignalsImages.m
@@ -1,4 +1,4 @@
-function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, validType] = modelGetSignalsImages(obj,varargin)
+function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, validType, inputSignals2] = modelGetSignalsImages(obj,varargin)
 	% Grabs input signals and images from current folder
 	% Biafra Ahanonu
 	% branched from controllerAnalysis: 2014.08.01 [16:09:16]
@@ -59,6 +59,8 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 	else
 		thisFileNum = options.fileNum;
 	end
+
+	inputSignals2 = [];
 
 	options.returnTypeTwo = options.returnType;
 	switch options.returnType
@@ -246,6 +248,8 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 			inputSignals = double(cnmfAnalysisOutput.extractedSignals);
 			% inputSignals = double(cnmfAnalysisOutput.extractedSignalsEst);
 
+			inputSignals2 = double(cnmfAnalysisOutput.extractedSignalsEst);
+
 			if options.loadAlgorithmPeaks==1
 				signalPeaks = cnmfAnalysisOutput.extractedPeaks>0;
 				nCells=size(signalPeaks,1);
@@ -266,6 +270,8 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 			% inputSignals = double(permute(extractAnalysisOutput.traces, [2 1]));
 			% inputSignals = double(cnmfeAnalysisOutput.extractedSignalsEst);
 			inputSignals = double(cnmfeAnalysisOutput.extractedSignals);
+
+			inputSignals2 = double(cnmfeAnalysisOutput.extractedSignalsEst);
 
 			if options.loadAlgorithmPeaks==1
 				signalPeaks = cnmfeAnalysisOutput.extractedPeaks>0;
@@ -305,6 +311,8 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 			else
 				inputSignals = emAnalysisOutput.cellTraces;
 			end
+
+			inputSignals2 = double(emAnalysisOutput.cellTraces);
 
 			% inputSignals = double(emAnalysisOutput.scaledProbabilityAlt);
 
@@ -425,6 +433,9 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 
 				case 'filtered'
 					inputSignals = inputSignals(valid,:);
+					if ~isempty(inputSignals2)
+						inputSignals2 = inputSignals2(valid,:);
+					end
 					signalPeaksArray = {obj.signalPeaksArray{thisFileNum}{valid}};
 					% signalPeaks = zeros([obj.nSignals{thisFileNum} obj.nFrames{thisFileNum}]);
 					signalPeaks = zeros([length(signalPeaksArray) obj.nFrames{thisFileNum}]);
@@ -434,6 +445,9 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 					% signalPeaks = signalPeaks(valid,:);
 				case 'filteredAndRegistered'
 					inputSignals = inputSignals(valid,:);
+					if ~isempty(inputSignals2)
+						inputSignals2 = inputSignals2(valid,:);
+					end
 					% inputImages = IcaFilters(valid,:,:);
 					signalPeaksArray = {obj.signalPeaksArray{thisFileNum}{valid}};
 
@@ -468,7 +482,9 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 						% get the global coordinate number based
 						% globalRegCoords = globalRegCoords{strcmp(obj.assay{thisFileNum},obj.globalIDFolders.(obj.subjectStr{thisFileNum}))};
                         % globalRegCoords = globalRegCoords{strcmp(obj.date{thisFileNum},obj.globalIDFolders.(obj.subjectStr{thisFileNum}))};
-                        globalRegCoords = globalRegCoords{strcmp(obj.folderBaseSaveStr{thisFileNum},obj.globalIDFolders.(obj.subjectStr{thisFileNum}))};
+                        % globalRegCoords = globalRegCoords{strcmp(obj.folderBaseSaveStr{thisFileNum},obj.globalIDFolders.(obj.subjectStr{thisFileNum}))};
+                        globalRegCoords = globalRegCoords{strcmp(obj.folderBaseSaveStrUnique{thisFileNum},obj.globalIDFolders.(obj.subjectStr{thisFileNum}))};
+
 						if ~isempty(globalRegCoords)
 							% inputImages = permute(inputImages,[2 3 1]);
 							for iterationNo = 1:length(globalRegCoords)

--- a/@calciumImagingAnalysis/modelPreprocessMovieFunction.m
+++ b/@calciumImagingAnalysis/modelPreprocessMovieFunction.m
@@ -939,7 +939,7 @@ function [ostruct] = modelPreprocessMovieFunction(obj,varargin)
 		    % thisMovie(:,:,movieSubset) = turboregMovie(thisMovie(:,:,movieSubset),'options',ioptions);
 		    % j = whos('turboregThisMovie');j.bytes=j.bytes*9.53674e-7;j
 		    j = whos('thisMovie');j.bytes=j.bytes*9.53674e-7;j;display(['movie size: ' num2str(j.bytes) 'Mb | ' num2str(j.size) ' | ' j.class]);
-	    	[thisMovie(:,:,movieSubset), ResultsOutOriginal{movieSubset}] = turboregMovie(thisMovie(:,:,movieSubset),'options',ioptions);
+	    	[thisMovie(:,:,movieSubset), ResultsOutOriginal{thisSet}] = turboregMovie(thisMovie(:,:,movieSubset),'options',ioptions);
 		    % if thisSet==1&thisSet~=nSubsets
 		    % 	% class(movieSubset)
 		    % 	% movieSubset

--- a/@calciumImagingAnalysis/modelPreprocessMovieFunction.m
+++ b/@calciumImagingAnalysis/modelPreprocessMovieFunction.m
@@ -14,6 +14,7 @@ function [ostruct] = modelPreprocessMovieFunction(obj,varargin)
 		% 2015.01.19 [20:43:49] - changed how turboreg is passed to function to improve memory usage, also moved dfof and downsample directly into function to reduce memory footprint there as well.
 		% 2016.06.22 [13:20:43] small code change to choosing what steps to perform
 		% 2019.01.23 [09:15:39] Added support for 2018b due to change in findjobj and uicontrol.
+		% 2019.04.17 [11:59:35] Saving turboreg outputs added, in same folder as the log.
 	% TODO
 		% Insert NaNs or mean of the movie into dropped frame location, see line 260
 		% Allow easy switching between analyzing all files in a folder together and each file in a folder individually
@@ -304,6 +305,7 @@ function [ostruct] = modelPreprocessMovieFunction(obj,varargin)
 			cd(obj.defaultObjDir);
 			currentDateTimeStr = datestr(now,'yyyymmdd_HHMMSS','local');
 			mkdir([thisDir filesep 'processing_info'])
+			thisProcessingDir = [thisDir filesep 'processing_info'];
 			diarySaveStr = [thisDir filesep 'processing_info' filesep currentDateTimeStr '_preprocess.log'];
 			display(['saving diary: ' diarySaveStr])
 			diary(diarySaveStr);
@@ -321,7 +323,7 @@ function [ostruct] = modelPreprocessMovieFunction(obj,varargin)
 			% add the folder to the output structure
 			ostruct.folderList{fileNum} = thisDir;
 
-			optionsSaveStr = [thisDir filesep 'processing_info' filesep '\preprocessingOptions_' currentDateTimeStr '.mat'];
+			optionsSaveStr = [thisDir filesep 'processing_info' filesep currentDateTimeStr '_preprocessingOptions' '.mat'];
 
 			if sum(strcmp(analysisOptionList(analysisOptionsIdx),'turboreg'))>0
 				turboRegCoordsTmp2 = turboRegCoords{fileNum};
@@ -423,7 +425,11 @@ function [ostruct] = modelPreprocessMovieFunction(obj,varargin)
 										% Miji;
 										manageMiji('startStop','start');
 									end
+									ResultsOutOriginal = {};
 									turboregInputMovie();
+
+									% Save output of translation.
+									save([thisProcessingDir filesep currentDateTimeStr '_turboregTranslationOutput.mat'],'ResultsOutOriginal');
 									if strcmp(options.turboreg.filterBeforeRegister,'imagejFFT')
 										% MIJ.exit;
 										manageMiji('startStop','exit');
@@ -933,7 +939,7 @@ function [ostruct] = modelPreprocessMovieFunction(obj,varargin)
 		    % thisMovie(:,:,movieSubset) = turboregMovie(thisMovie(:,:,movieSubset),'options',ioptions);
 		    % j = whos('turboregThisMovie');j.bytes=j.bytes*9.53674e-7;j
 		    j = whos('thisMovie');j.bytes=j.bytes*9.53674e-7;j;display(['movie size: ' num2str(j.bytes) 'Mb | ' num2str(j.size) ' | ' j.class]);
-	    	[thisMovie(:,:,movieSubset)] = turboregMovie(thisMovie(:,:,movieSubset),'options',ioptions);
+	    	[thisMovie(:,:,movieSubset), ResultsOutOriginal{movieSubset}] = turboregMovie(thisMovie(:,:,movieSubset),'options',ioptions);
 		    % if thisSet==1&thisSet~=nSubsets
 		    % 	% class(movieSubset)
 		    % 	% movieSubset

--- a/@calciumImagingAnalysis/viewMatchObjBtwnSessions.m
+++ b/@calciumImagingAnalysis/viewMatchObjBtwnSessions.m
@@ -103,7 +103,9 @@ function obj = viewMatchObjBtwnSessions(obj)
                 display(repmat('*',1,7))
 				display([num2str(idx) '/' num2str(length(validFoldersIdx)) ': ' obj.fileIDNameArray{thisFileNum}]);
 				% folderGlobalIdx = find(strcmp(obj.assay(thisFileNum),globalIDFolders));
-                folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(thisFileNum),globalIDFolders));
+
+				% folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(thisFileNum),globalIDFolders));
+                folderGlobalIdx = find(strcmp(obj.folderBaseSaveStrUnique(thisFileNum),globalIDFolders));
 				if isempty(folderGlobalIdx)
 					display('skipping...')
 					continue
@@ -126,7 +128,9 @@ function obj = viewMatchObjBtwnSessions(obj)
 				display(repmat('*',1,7))
 				display([num2str(idx) '/' num2str(length(validFoldersIdx)) ': ' obj.fileIDNameArray{thisFileNum}]);
 				% folderGlobalIdx = find(strcmp(obj.assay(thisFileNum),globalIDFolders));
-                folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(thisFileNum),globalIDFolders));
+
+                folderGlobalIdx = find(strcmp(obj.folderBaseSaveStrUnique(thisFileNum),globalIDFolders));
+                % folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(thisFileNum),globalIDFolders));
                 %folderGlobalIdx = idx;
 				if isempty(folderGlobalIdx)
 					display('skipping...')
@@ -178,7 +182,9 @@ function obj = viewMatchObjBtwnSessions(obj)
 			for sessionNo = 1:nSessions
 				obj.fileNum = validFoldersIdx(sessionNo);
 				% folderGlobalIdx = find(strcmp(obj.assay(obj.fileNum),globalIDFolders));
-                folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(obj.fileNum),globalIDFolders));
+
+				folderGlobalIdx = find(strcmp(obj.folderBaseSaveStrUnique(obj.fileNum),globalIDFolders));
+                % folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(obj.fileNum),globalIDFolders));
 				for globalNo = 1:nGlobalIDs
 					sessionIdx = globalIDsTmp(globalNo,folderGlobalIdx);
 					if sessionIdx~=0
@@ -196,7 +202,8 @@ function obj = viewMatchObjBtwnSessions(obj)
 				try
 					obj.fileNum = validFoldersIdx(sessionNo);
 					thisFileID = obj.fileIDArray{obj.fileNum};
-					folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(obj.fileNum),globalIDFolders));
+					folderGlobalIdx = find(strcmp(obj.folderBaseSaveStrUnique(obj.fileNum),globalIDFolders));
+					% folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(obj.fileNum),globalIDFolders));
 					% globalToSessionIDsTmp = globalToSessionIDs{sessionNo};
 					% keepIDIdx = globalIDs(nMatchGlobalIDs>=2,sessionNo);
 					% keepIDIdx(keepIDIdx<1) = [];
@@ -254,7 +261,9 @@ function obj = viewMatchObjBtwnSessions(obj)
 					for sessionNo = 1:nSessions
 						obj.fileNum = validFoldersIdx(sessionNo);
 						thisFileID = obj.fileIDArray{obj.fileNum};
-						folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(obj.fileNum),globalIDFolders));
+						% folderGlobalIdx = find(strcmp(obj.folderBaseSaveStr(obj.fileNum),globalIDFolders));
+						folderGlobalIdx = find(strcmp(obj.folderBaseSaveStrUnique(obj.fileNum),globalIDFolders));
+
 						sessionIdx = globalIDsTmp(globalNo,folderGlobalIdx);
 						if sessionIdx~=0
 							tt = obj.globalIDCoords.(thisSubjectStr).localCoords{sessionNo}(sessionIdx,:);
@@ -438,7 +447,9 @@ function obj = viewMatchObjBtwnSessions(obj)
 							% imagesc(globalToSessionIDs{sessionNo})
 							imagesc(thisCellmap+1);box off;axis off;
 							% title(strrep(obj.assay(obj.fileNum),'_',' '))
-							title(strrep(obj.folderBaseSaveStr(obj.fileNum),'_',' '))
+
+							title(strrep(obj.folderBaseSaveStrUnique(obj.fileNum),'_',' '))
+							% title(strrep(obj.folderBaseSaveStr(obj.fileNum),'_',' '))
 							% colormap(customColormap([]))
 							% colormap([1 1 1; hsv(nGlobalIDs)]);
 							colormap([1 1 1; 0.9 0.9 0.9; hsv(nGlobalIDs)]);

--- a/@calciumImagingAnalysis/viewMatchObjBtwnSessions.m
+++ b/@calciumImagingAnalysis/viewMatchObjBtwnSessions.m
@@ -9,6 +9,7 @@ function obj = viewMatchObjBtwnSessions(obj)
 
 	% changelog
 		% 2017.01.14 [20:06:04] - support switched from [nSignals x y] to [x y nSignals]
+		% 2019.04.23 [19:53:21] - a couple Windows specific path separators, switch to filesep
 	% TODO
 		%
 
@@ -441,7 +442,7 @@ function obj = viewMatchObjBtwnSessions(obj)
 							% title(strrep(obj.folderBaseSaveStr(obj.fileNum),'_',' '))
 							colormap([1 1 1; 0.9 0.9 0.9; hsv(nGlobalIDs)]);
 							set(sessionNo,'PaperUnits','inches','PaperPosition',[0 0 9 9])
-							obj.modelSaveImgToFile([],[folderSaveName{matchingNumbers} 'Session\' thisSubjectStr],sessionNo,strcat(thisFileID));
+							obj.modelSaveImgToFile([],[folderSaveName{matchingNumbers} 'Session' filesep thisSubjectStr],sessionNo,strcat(thisFileID));
 						[~, ~] = openFigure(thisFigNo, '');
 						subplot(1,nSessions,sessionNo)
 							% imagesc(globalToSessionIDs{sessionNo})
@@ -472,7 +473,7 @@ function obj = viewMatchObjBtwnSessions(obj)
 				for sessionNo = 1:nSessions
 					obj.fileNum = validFoldersIdx(sessionNo);
 					thisFileID = obj.fileIDArray{obj.fileNum};
-					obj.modelSaveImgToFile([],['matchObjColorMapSession\' thisSubjectStr],sessionNo,strcat(thisFileID));
+					obj.modelSaveImgToFile([],['matchObjColorMapSession' filesep thisSubjectStr],sessionNo,strcat(thisFileID));
 					set(sessionNo,'PaperUnits','inches','PaperPosition',[0 0 9 9])
 
 					frame = getframe(sessionNo);

--- a/@calciumImagingAnalysis/viewMovieRegistrationTest.m
+++ b/@calciumImagingAnalysis/viewMovieRegistrationTest.m
@@ -35,6 +35,12 @@ function obj = viewMovieRegistrationTest(obj)
 			end
 		end
 
+		for figNoFake = [9 4242 456 457 9019]
+		    [~, ~] = openFigure(figNoFake, '');
+		    clf
+		end
+	    drawnow
+
 		movieSettings = inputdlg({...
 				'start:end frames (leave blank for all)',...
 				'number of turboreg test to run',...

--- a/image/thresholdImages.m
+++ b/image/thresholdImages.m
@@ -17,6 +17,7 @@ function [inputImages, boundaryIndices, numObjects] = thresholdImages(inputImage
         % 2017.01.14 [20:06:04] - support switched from [nSignals x y] to [x y nSignals]
         % 2017 or 2018 - added boundaryIndices support.
         % 2019.03.05 [19:21:30] Change to using bwareafilt to remove unconnected points from main structure
+        % 2019.04.23 [19:51:26] Deal with images that are all zeros.
     % TODO
         %
 
@@ -154,8 +155,12 @@ function [inputImages, boundaryIndices, numObjects] = thresholdImages(inputImage
             end
 
         elseif options_normalize==1
-            % normalize
-            thisFilt=thisFilt/maxVal;
+            % normalize, don't divide by zero (e.g. for zero variance images)
+            if maxVal~=0
+                thisFilt=thisFilt/maxVal;
+            else
+            end
+            thisFilt(isnan(thisFilt)) = replaceVal;
         else
             % do nothing
         end

--- a/io/getFileInfo.m
+++ b/io/getFileInfo.m
@@ -54,7 +54,7 @@ function [fileInfo] = getFileInfo(fileStr, varargin)
 	options.planeRegexp = 'plane\d+';
 
 	options.trialList = {...
-	'01habit|02lickSession|03thresholds|04stimuliBlockOne|05stimuliBlockTwo|06stimuliBlockThree|07stimuliBlockFour|08stimuliBlockFive|baseline1|baseline2|baseline3|baseline4|baseline5'};
+	'01habit|02lickSession|03thresholds|04stimuliBlockOne|05stimuliBlockTwo|06stimuliBlockThree|07stimuliBlockFour|08stimuliBlockFive|baseline1|baseline2|baseline3|baseline4|baseline5|trial'};
 
 	% get options
 	options = getOptions(options,varargin);

--- a/io/moveFilesToFolders.m
+++ b/io/moveFilesToFolders.m
@@ -1,0 +1,89 @@
+function [success destFolders] = moveFilesToFolders(pathToSrc,pathToDest,varargin)
+    % copies folder structure (i.e. only folders, not files) from src to dest then searches for files in dest that are in src subfolders and moves them to their corresponding subfolders in dest. this is NOT recursive.
+    % biafra ahanonu
+    % started: 2014.01.03 [19:13:01]
+    % inputs
+        % pathToSrc
+        % pathToDest
+    % outputs
+        %
+
+    % changelog
+        %
+    % TODO
+        %
+
+    %========================
+    % used to determine which folders to copy from src to dest
+    options.srcFolderFilterRegexp = '201\d';
+    % this regexp is used to search the destination directory
+    options.srcSubfolderFileFilterRegexp = 'recording.*.(txt|xml)';%xml
+    %
+    options.srcSubfolderFileFilterRegexpExt = '(.txt|.xml)';
+    % get options
+    options = getOptions(options,varargin);
+    % display(options)
+    % unpack options into current workspace
+    % fn=fieldnames(options);
+    % for i=1:length(fn)
+    %   eval([fn{i} '=options.' fn{i} ';']);
+    % end
+    %========================
+    success = 0;
+    try
+        % get a list of the folders to move and search for files
+        listOfSrcFolders = getFileList(pathToSrc,options.srcFolderFilterRegexp);
+        nFolders = length(listOfSrcFolders);
+        %
+        destFolders = {};
+
+        % for each folder from the source directory, find all of the relevant
+        % files and move them into appropriate sub-directories
+        for i = 1:nFolders
+            loopFolder = listOfSrcFolders{i};
+            % get the base folder name, create a copy in destination directory
+            [pathstr,destFolderName,ext] = fileparts(loopFolder);
+            destFolderMovePath = [pathToDest '\' destFolderName];
+
+            % for each folder, filter for specific file name scheme
+            loopFolderFiles = getFileList(loopFolder,options.srcSubfolderFileFilterRegexp);
+            loopFolderFiles = regexp(loopFolderFiles, options.srcSubfolderFileFilterRegexp,'match');
+            if ~isempty(loopFolderFiles)
+                % loop over each src subfolder file, use it as a regexp to find and move dest files
+                for j = 1:length(loopFolderFiles)
+                    display(repmat('_',1,7))
+                    iFile = regexprep(loopFolderFiles{j},options.srcSubfolderFileFilterRegexpExt,'');
+                    filesToMove = getFileList(pathToDest,iFile);
+                    if ~isempty(filesToMove)
+                        destFolders{end+1} = destFolderMovePath;
+                        for k = 1:length(filesToMove)
+                            thisFileToMoveSrc = filesToMove{k};
+                            [pathstr,fileToMove,ext] = fileparts(thisFileToMoveSrc);
+                            thisFileToMoveSrc
+                            thisFileToMoveDest = [destFolderMovePath '\' fileToMove ext]
+                            if ~exist(destFolderMovePath,'file')
+                                mkdir(pathToDest,destFolderName);
+                            end
+                            % use system calls to move files, appears to be fastest method
+                            if ispc
+                                dos(['move ' thisFileToMoveSrc ' ' thisFileToMoveDest]);
+                            elseif isunix
+                                unix(['mv ' thisFileToMoveSrc ' ' thisFileToMoveDest]);
+                            end
+                            % java.io.File(thisFileToMoveSrc).renameTo(java.io.File(thisFileToMoveDest));
+                            % movefile(thisFileToMoveSrc,thisFileToMoveDest)
+                        end
+                    else
+                        display(char(strcat('no matching files: ',loopFolder,loopFolderFiles{j})));
+                    end
+                end
+            end
+        end
+        success = 1;
+    catch err
+        display(repmat('@',1,7))
+        disp(getReport(err,'extended','hyperlinks','on'));
+        display(repmat('@',1,7))
+        success = 0;
+    end
+end

--- a/movie_processing/normalizeMovie.m
+++ b/movie_processing/normalizeMovie.m
@@ -62,7 +62,7 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 	options.medianFilterNeighborhoodSize = 6;
 	% type of padding, zeros/symmetric/indexed
 	options.medianFilterPadding = 'symmetric';
-	% Version of pad image to use for FFT, 1 = original, 2 = make image dimensions power of 2.
+	% Version of pad image to use for FFT, 1 = original, 2 = make image dimensions power of 2 (speeds up computation in many cases).
 	options.padImageVersion = 2;
 	% ===
 	% cmd line waitbar on?

--- a/neighbor/identifyNeighborsAuto.m
+++ b/neighbor/identifyNeighborsAuto.m
@@ -31,6 +31,11 @@ function neighborsCell = identifyNeighborsAuto(inputImages, inputSignals, vararg
 
     options.inputImagesThres = [];;
 
+    %
+    options.startCellNo = 1;
+    %
+    options.cropSizeLength = 20;
+
     % get options
     options = getOptions(options,varargin);
     % unpack options into current workspace

--- a/neighbor/viewNeighborsAuto.m
+++ b/neighbor/viewNeighborsAuto.m
@@ -90,7 +90,8 @@ function viewNeighborsAuto(inputImages, inputSignals, neighborsCell, varargin)
             imAlpha(isnan(croppedPeakImages2))=0;
             imagesc(croppedPeakImages2,'AlphaData',imAlpha);
             set(gca,'color',[0 0 0]);
-            title(['#' num2str(cellnum) '/' num2str(nCells) ' | neighboring cells | top-left = this cell'])
+            title(['#' num2str(cellnum) '/' num2str(nCells) ' | neighboring cells' 10 'top-left = this cell, #s increase L->R and T->B'])
+            axis equal tight
 
         % plot the traces
         subplot(2,3,[1:2 4:5])
@@ -99,7 +100,8 @@ function viewNeighborsAuto(inputImages, inputSignals, neighborsCell, varargin)
             axis tight
             xlabel('Time (frames)')
             ylabel('Cell activity')
-            title(instructionStr);
+            % suptitle(instructionStr);
+            zoom on
 
         % plot correlations
         subplot(2,3,6)
@@ -113,11 +115,24 @@ function viewNeighborsAuto(inputImages, inputSignals, neighborsCell, varargin)
             % imagesc(l);
             xlabel('cells');
             ylabel('cells');
-            title(['cell-cell trace correlations | cell #1 = this cell']);
+            title(['cell-cell trace correlations' 10 'cell #1 = this cell']);
+            box off; axis equal tight
+            caxis([0 1])
 
-
+        suptitle(instructionStr);
         set(findall(gcf,'-property','FontSize'),'FontSize',13);
-        [x,y,reply]=ginput(1);
+        % [x,y,reply]=ginput(1);
+
+        set(gcf,'currentch','3');
+        keyIn = get(gcf,'CurrentCharacter');
+
+        while strcmp(keyIn,'3')
+            keyIn = get(gcf,'CurrentCharacter');
+            pause(0.05);
+        end
+        reply = double(keyIn);
+        set(gcf,'currentch','3');
+
         [valid directionOfNextChoice exitLoop cellnum] = respondToUserInput(reply,cellnum,valid,directionOfNextChoice,exitLoop,nCells);
 
         cellnum=cellnum+directionOfNextChoice;
@@ -128,6 +143,7 @@ function viewNeighborsAuto(inputImages, inputSignals, neighborsCell, varargin)
             cellnum = 1;
         end
     end
+    close(21)
 
 end
 

--- a/view/playMovie.m
+++ b/view/playMovie.m
@@ -377,10 +377,12 @@ function [exitSignal ostruct] = playMovie(inputMovie, varargin)
 			    end
 
 		    	% colormap gray
-		    	ylim([-0.05 max(max(options.extraLinePlot))]);
+		    	% ylim([-0.05 max(max(options.extraLinePlot))]);
+		    	ylim([nanmin(options.extraLinePlot(:)) nanmax(options.extraLinePlot(:))]);
 		    	xval = 0;
 		    	x=[xval,xval];
-		    	y=[-0.05 max(max(options.extraLinePlot))];
+		    	% y=[-0.05 max(max(options.extraLinePlot))];
+		    	y=[nanmin(options.extraLinePlot(:)) nanmax(options.extraLinePlot(:))];
 		    	plot(x,y,'r'); box off; hold on
 		    	% hold off;
 		    	if ~isempty(options.extraLinePlotLegend)

--- a/view/setFigureDefaults.m
+++ b/view/setFigureDefaults.m
@@ -16,8 +16,31 @@ function setFigureDefaults()
 
 	% scnsize = get(0,'ScreenSize');
 	% pos1 = [scnsize(3)/2, 10, scnsize(3)/2-20, scnsize(4)-100];
-	defaultFontStr = 'Futura Std Book';
-	defaultUIFontStr = 'Arial';
+	% defaultFontStr = 'Futura Std Book';
+	% defaultUIFontStr = 'Arial';
+
+	% defaultFontStr = 'Futura Std Book';
+	% defaultUIFontStr = 'Futura Std Book';
+
+	defaultFontStr = 'Consolas';
+	defaultUIFontStr = 'Consolas';
+
+	% Change the command window and editor fonts
+	FontSize = 12;
+	% java.awt.Font.BOLD
+	if ismac
+		cmdWinEditorFont = 'Menlo-Regular';
+	elseif isunix
+	    cmdWinEditorFont = 'Consolas';
+	elseif ispc
+		cmdWinEditorFont = 'Consolas';
+	else
+	    disp('Platform not supported')
+	end
+
+	com.mathworks.services.FontPrefs.setCodeFont(java.awt.Font(cmdWinEditorFont,0,FontSize))
+    com.mathworks.services.FontPrefs.setTextFont(java.awt.Font(cmdWinEditorFont,0,FontSize))
+
 	% 'DefaultLineLineSmoothing','on',...
 	% 'DefaultPatchLineSmoothing','on',...
 	% set(0,'DefaultFigureWindowStyle','docked')


### PR DESCRIPTION
- Cross-session now supports user sessions that don't have names recognized by `getFileInfo`.
- `signalSorter` supports input of secondary trace for use with trace and ROI viewer (`r` in the GUI).
- `moveFilesToFolders` added to the repo. Used with `modelDownsampleRawMovies`.