### PR TITLE
 signalSorter improvements, general git downloader, and misc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ data/
 signal_extraction/cnmf_current
 signal_extraction/cnmfe
 signal_extraction/cvx_rd
+_external_programs/
+_external_programs/cnmf_current
+_external_programs/cnmfe
+_external_programs/cvx_rd
+
 
 # Signal extraction dependency zips
 signal_extraction/*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,13 @@ data/
 signal_extraction/cnmf_current
 signal_extraction/cnmfe
 signal_extraction/cvx_rd
-_external_programs/
+_external_programs/*/
 _external_programs/cnmf_current
 _external_programs/cnmfe
 _external_programs/cvx_rd
 
 # Signal extraction dependency zips
+_external_programs/*.zip
 signal_extraction/*.zip
 /*.mat
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ _external_programs/cnmf_current
 _external_programs/cnmfe
 _external_programs/cvx_rd
 
-
 # Signal extraction dependency zips
 signal_extraction/*.zip
 /*.mat

--- a/@calciumImagingAnalysis/calciumImagingAnalysis.m
+++ b/@calciumImagingAnalysis/calciumImagingAnalysis.m
@@ -28,7 +28,7 @@ classdef calciumImagingAnalysis < dynamicprops
 		MICRON_PER_PIXEL =  2.51; % 2.37;
 
 		defaultObjDir = pwd;
-		classVersion = 'v3.2.4-20190725';
+		classVersion = 'v3.3.1-20190811';
 		serverPath = '';
 		privateSettingsPath = ['private' filesep 'settings' filesep 'privateLoadBatchFxns.m'];
 		% place where functions can temporarily story user settings

--- a/@calciumImagingAnalysis/computeManualSortSignals.m
+++ b/@calciumImagingAnalysis/computeManualSortSignals.m
@@ -346,6 +346,10 @@ function obj = computeManualSortSignals(obj)
 						validCNMFE = valid;
 						methodStr = obj.extractionMethodSortedSaveStr.(obj.signalExtractionMethod);
 						saveVariable = {obj.extractionMethodValidVarname.(obj.signalExtractionMethod)};
+					case 'ROI'
+						validROI = valid;
+						methodStr = obj.extractionMethodSortedSaveStr.(obj.signalExtractionMethod);
+						saveVariable = {obj.extractionMethodValidVarname.(obj.signalExtractionMethod)};
 					otherwise
 						% body
 				end

--- a/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
+++ b/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
@@ -38,7 +38,7 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 	scnsize = get(0,'ScreenSize');
 	signalExtractionMethodStr = {'EM','PCAICA','PCAICA_old','CNMF','CNMFE','EXTRACT','ROI'};
 	currentIdx = find(strcmp(signalExtractionMethodStr,obj.signalExtractionMethod));
-	signalExtractionMethodDisplayStr = {'CELLMax (Lacey/Biafra)','PCAICA (Mukamel, 2009) | Hakan/Tony version','PCAICA (Mukamel, 2009) | Jerome Lecoq version','CNMF (Pnevmatikakis, 2016 or Giovannucci, 2019)','CNMF-E (Zhou, 2018)','EXTRACT (Hakan)','ROI - only do after running either PCAICA, CELLMax, EXTRACT, or CNMF'};
+	signalExtractionMethodDisplayStr = {'CELLMax (Lacey/Biafra)','PCAICA (Mukamel, 2009) | Hakan/Tony version','PCAICA (Mukamel, 2009) | Jerome Lecoq version','CNMF (Pnevmatikakis, 2016 or Giovannucci, 2019)','CNMF-E (Zhou, 2018)','EXTRACT (Inan, 2017)','ROI - only do after running either PCAICA, CELLMax, EXTRACT, or CNMF'};
 	[signalIdxArray, ok] = listdlg('ListString',signalExtractionMethodDisplayStr,'ListSize',[scnsize(3)*0.4 scnsize(4)*0.4],'Name','which signal extraction method?','InitialValue',currentIdx);
 	% signalIdxArray
 	signalExtractionMethod = signalExtractionMethodStr(signalIdxArray);
@@ -529,9 +529,12 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 					);setNo = 1;
 					options.ROI.threshold = str2num(movieSettings{setNo});setNo = setNo+1;
 
-					signalExtractionMethodStr2 = {'PCAICA','EM','EXTRACT','CNMF'};
+					% signalExtractionMethodStr2 = {'PCAICA','EM','EXTRACT','CNMF'};
+					signalExtractionMethodStr2 = {'EM','PCAICA','CNMF','CNMFE','EXTRACT'};
+
 					currentIdx = find(strcmp(signalExtractionMethodStr2,obj.signalExtractionMethod));
-					signalExtractionMethodDisplayStr2 = {'PCAICA','CELLMax (Lacey)','EXTRACT (Hakan)','CNMF (Pnevmatikakis, 2015)'};
+					% signalExtractionMethodDisplayStr2 = {'PCAICA','CELLMax (Lacey)','EXTRACT (Hakan)','CNMF (Pnevmatikakis, 2015)'};
+					signalExtractionMethodDisplayStr2 = {'CELLMax (Lacey/Biafra)','PCAICA (Mukamel, 2009)','CNMF (Pnevmatikakis, 2016 or Giovannucci, 2019)','CNMF-E (Zhou, 2018)','EXTRACT (Inan, 2017)','ROI - only do after running either PCAICA, CELLMax, EXTRACT, or CNMF'};
 					[signalIdxArray2, ~] = listdlg('ListString',signalExtractionMethodDisplayStr2,'ListSize',[scnsize(3)*0.4 scnsize(4)*0.4],'Name','Which signal extraction method for ROI? SELECT ONE','InitialValue',currentIdx);
 					% signalIdxArray
 					options.ROI.signalExtractionMethod = signalExtractionMethodStr2{signalIdxArray2};

--- a/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
+++ b/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
@@ -16,6 +16,7 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 	% changelog
 		% 2016.02.19 - rewrite of code to allow non-overwrite mode, so that multiple computers can connect to the same server and process the same series of folders in parallel while automatically ignoring folders that have already been processed. Could extend to include some date-based measure for analysis re-runs
 		% 2019.04.15 - Added new method of inputting CNMF-E settings using MATLAB editor. More flexible.
+		% 2019.08.20 [12:29:31] - Contrast added to cell size/width decision-making.
 	% TODO
 		%
 
@@ -35,9 +36,9 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 	if ~exist(obj.settingsSavePath,'dir');mkdir(obj.settingsSavePath);fprintf('Creating directory: %s\n',obj.settingsSavePath);end
 
 	scnsize = get(0,'ScreenSize');
-	signalExtractionMethodStr = {'PCAICA','PCAICA_old','EM','EXTRACT','CNMF','CNMFE','ROI'};
+	signalExtractionMethodStr = {'EM','PCAICA','PCAICA_old','CNMF','CNMFE','EXTRACT','ROI'};
 	currentIdx = find(strcmp(signalExtractionMethodStr,obj.signalExtractionMethod));
-	signalExtractionMethodDisplayStr = {'PCAICA (Mukamel, 2009) | Hakan/Tony version','PCAICA (Mukamel, 2009) | Jerome version','CELLMax (Lacey/Biafra)','EXTRACT (Hakan)','CNMF (Pnevmatikakis, 2016)','CNMF-E (Zhou, 2018)','ROI - only do after running either PCAICA, CELLMax, EXTRACT, or CNMF'};
+	signalExtractionMethodDisplayStr = {'CELLMax (Lacey/Biafra)','PCAICA (Mukamel, 2009) | Hakan/Tony version','PCAICA (Mukamel, 2009) | Jerome Lecoq version','CNMF (Pnevmatikakis, 2016 or Giovannucci, 2019)','CNMF-E (Zhou, 2018)','EXTRACT (Hakan)','ROI - only do after running either PCAICA, CELLMax, EXTRACT, or CNMF'};
 	[signalIdxArray, ok] = listdlg('ListString',signalExtractionMethodDisplayStr,'ListSize',[scnsize(3)*0.4 scnsize(4)*0.4],'Name','which signal extraction method?','InitialValue',currentIdx);
 	% signalIdxArray
 	signalExtractionMethod = signalExtractionMethodStr(signalIdxArray);
@@ -1381,6 +1382,8 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 				maxProj=max(DFOF,[],3);
 				imagesc(squeeze(maxProj));
 				colormap gray;
+				imcontrast
+				figure(mainFig)
 				% imellipse has different behavior depending on axis in 2015b and 2017a
 				% if verLessThan('matlab','9.0')
 				% 	axis equal;

--- a/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
+++ b/@calciumImagingAnalysis/modelExtractSignalsFromMovie.m
@@ -534,7 +534,7 @@ function obj = modelExtractSignalsFromMovie(obj,varargin)
 
 					currentIdx = find(strcmp(signalExtractionMethodStr2,obj.signalExtractionMethod));
 					% signalExtractionMethodDisplayStr2 = {'PCAICA','CELLMax (Lacey)','EXTRACT (Hakan)','CNMF (Pnevmatikakis, 2015)'};
-					signalExtractionMethodDisplayStr2 = {'CELLMax (Lacey/Biafra)','PCAICA (Mukamel, 2009)','CNMF (Pnevmatikakis, 2016 or Giovannucci, 2019)','CNMF-E (Zhou, 2018)','EXTRACT (Inan, 2017)','ROI - only do after running either PCAICA, CELLMax, EXTRACT, or CNMF'};
+					signalExtractionMethodDisplayStr2 = {'CELLMax (Lacey/Biafra)','PCAICA (Mukamel, 2009)','CNMF (Pnevmatikakis, 2016 or Giovannucci, 2019)','CNMF-E (Zhou, 2018)','EXTRACT (Inan, 2017)'};
 					[signalIdxArray2, ~] = listdlg('ListString',signalExtractionMethodDisplayStr2,'ListSize',[scnsize(3)*0.4 scnsize(4)*0.4],'Name','Which signal extraction method for ROI? SELECT ONE','InitialValue',currentIdx);
 					% signalIdxArray
 					options.ROI.signalExtractionMethod = signalExtractionMethodStr2{signalIdxArray2};

--- a/@calciumImagingAnalysis/modelGetSignalsImages.m
+++ b/@calciumImagingAnalysis/modelGetSignalsImages.m
@@ -304,8 +304,8 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 				obj.nSignals{thisFileNum} = size(signalPeaks,1);
 			end
 
-			inputSignals = normalizeCELLMaxTraces(inputSignals,inputImages);
-			inputSignals2 = normalizeCELLMaxTraces(inputSignals2,inputImages);
+			inputSignals = normalizeSignalExtractionActivityTraces(inputSignals,inputImages);
+			inputSignals2 = normalizeSignalExtractionActivityTraces(inputSignals2,inputImages);
 
 			% inputSignals = extractAnalysisOutput.traces;
 			% inputImages = permute(extractAnalysisOutput.filters,[3 1 2]);
@@ -364,8 +364,8 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 			inputSignals2 = double(emAnalysisOutput.cellTraces);
 
 			% Convert to dF/F values
-			inputSignals = normalizeCELLMaxTraces(inputSignals,inputImages);
-			inputSignals2 = normalizeCELLMaxTraces(inputSignals2,inputImages);
+			inputSignals = normalizeSignalExtractionActivityTraces(inputSignals,inputImages);
+			inputSignals2 = normalizeSignalExtractionActivityTraces(inputSignals2,inputImages);
 
 			% inputSignals = double(emAnalysisOutput.scaledProbabilityAlt);
 

--- a/@calciumImagingAnalysis/modelGetSignalsImages.m
+++ b/@calciumImagingAnalysis/modelGetSignalsImages.m
@@ -303,6 +303,10 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 				obj.signalPeaks{thisFileNum} = signalPeaks;
 				obj.nSignals{thisFileNum} = size(signalPeaks,1);
 			end
+
+			inputSignals = normalizeCELLMaxTraces(inputSignals,inputImages);
+			inputSignals2 = normalizeCELLMaxTraces(inputSignals2,inputImages);
+
 			% inputSignals = extractAnalysisOutput.traces;
 			% inputImages = permute(extractAnalysisOutput.filters,[3 1 2]);
 		end
@@ -337,6 +341,9 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 			% else
 			% 	inputSignals = emAnalysisOutput.dsCellTraces;
 			% end
+			% inputImages = permute(emAnalysisOutput.cellImages,[3 1 2]);
+			inputImages = emAnalysisOutput.cellImages;
+
 			if isfield(emAnalysisOutput,'scaledProbability')
 				display('using scaled probability...')
 				inputSignals = double(emAnalysisOutput.scaledProbability);
@@ -356,10 +363,12 @@ function [inputSignals, inputImages, signalPeaks, signalPeaksArray, valid, valid
 
 			inputSignals2 = double(emAnalysisOutput.cellTraces);
 
+			% Convert to dF/F values
+			inputSignals = normalizeCELLMaxTraces(inputSignals,inputImages);
+			inputSignals2 = normalizeCELLMaxTraces(inputSignals2,inputImages);
+
 			% inputSignals = double(emAnalysisOutput.scaledProbabilityAlt);
 
-			% inputImages = permute(emAnalysisOutput.cellImages,[3 1 2]);
-			inputImages = emAnalysisOutput.cellImages;
 
 			if options.loadAlgorithmPeaks==1
 				signalPeaksArray = emAnalysisOutput.eventTimes;

--- a/@calciumImagingAnalysis/modelTrackingData.m
+++ b/@calciumImagingAnalysis/modelTrackingData.m
@@ -259,6 +259,7 @@ function obj = modelTrackingData(obj)
 						assayIdx = strcmp(fileAssays,uniquefileAssays{idNum3});
 						fileIdx = dateIdx&subjectIdx&assayIdx;
 						if sum(fileIdx)==0
+							display('skipping...')
 							continue
 						end
 						display('===================')

--- a/@calciumImagingAnalysis/viewCreateObjmaps.m
+++ b/@calciumImagingAnalysis/viewCreateObjmaps.m
@@ -278,6 +278,7 @@ function obj = viewCreateObjmaps(obj,varargin)
 				inputSignalsTmp = inputSignalsTmp(validManual,:);
 				inputImagesTmp = inputImagesTmp(:,:,validManual);
 				signalPeaksTmp = signalPeaksTmp(validManual,:);
+				signalPeakIdxTmp = signalPeakIdxTmp(validManual);
 				% get raw background movie
 				movieList = getFileList(obj.inputFolders{obj.fileNum}, 'concat');
 				if isempty(movieList)
@@ -375,12 +376,17 @@ function obj = viewCreateObjmaps(obj,varargin)
 					inputSignalsTmp = inputSignalsTmp(validRegion,:);
 					inputImagesTmp = inputImagesTmp(:,:,validRegion);
 					signalPeaksTmp = signalPeaksTmp(validRegion,:);
+					signalPeakIdxTmp = signalPeakIdxTmp(validRegion);
 					cellCoords = cellCoords(validRegion,:);
 
 					% look at
 					sortedinputSignals = signalPeaksTmp.*inputSignalsTmp;
 					if isempty(options.signalCutIdx)
-						[signalSnr sortedIdx] = sort(max(sortedinputSignals,[],2),'descend');
+						% [signalSnr sortedIdx] = sort(max(sortedinputSignals,[],2),'descend');
+
+						[signalSnr a] = computeSignalSnr(inputSignalsTmp,'testpeaks',signalPeaksTmp,'testpeaksArray',signalPeakIdxTmp);
+						signalSnr(isinf(signalSnr)) = 0;
+						[signalSnr sortedIdx] = sort(signalSnr,'descend');
 					else
 						[signalSnr sortedIdx] = sort(max(sortedinputSignals(:,options.signalCutIdx),[],2),'descend');
 					end
@@ -525,8 +531,19 @@ function obj = viewCreateObjmaps(obj,varargin)
 					if ~isempty(options.signalCutXline)
 
 					end
-				end
 
+					openFigure(48484848, '');
+
+						plotTracesFigure();
+
+						% rectangle('Position',[0 0 10 3],'FaceColor',[0 0 0],'EdgeColor','none')
+
+						axis tight;
+						if ~isempty(options.signalCutXline)
+
+						end
+					[figHandle figNo] = openFigure(options.mapTraceGraphNo, '');
+				end
 				inputImages2 = inputImages;
 				[inputImages2 boundaryIndices] = thresholdImages(inputImages2,'binary',0,'getBoundaryIndex',0,'threshold',userThreshold);
 				% [inputImages2 boundaryIndices] = thresholdImages(inputImages2,'binary',0,'getBoundaryIndex',0,'threshold',0.2,'imageFilter',options.medianFilterImages,'imageFilterBinary',options.medianFilterImages);

--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ Contact: __Biafra Ahanonu, PhD (bahanonu [at] alum.mit.edu)__.
 
 ## Quick start guide
 
-Below are steps needed to quickly get started using the `calciumImagingAnalysis` software package.
+Below are steps needed to quickly get started using the `calciumImagingAnalysis` software package in MATLAB.
 - Clone the `calciumImagingAnalysis` repository (using GitHub desktop or command line) or download the repository zip and unzip.
 - Point the MATLAB path to the `calciumImagingAnalysis` folder.
 - Run the below MATLAB commands.
 - For Fiji dependency, when path to `Miji.m` (`\Fiji.app\scripts` folder) is requested, likely in `private\programs\FIJI_PATH\Fiji.app\scripts` unless the user requested a custom path or on OSX (in which case, find the install directory).
-- `calciumImagingAnalysis` often uses regular expressions to find relevant movie and other files in folders to analyze. For example, by default it looks for any files containing `concat`, e.g. `concat_recording_20140401_180333.h5` (test data). If you have a file called `rawData_2019_01_01_myInterestingExperiment.avi` and all your raw data files start with `rawData_` then change the regular expression to `rawData_` when requested by the repository. See `setMovieInfo` module.
+- `calciumImagingAnalysis` often uses regular expressions to find relevant movie and other files in folders to analyze.
+ - For example, by default it looks for any files containing `concat`, e.g. `concat_recording_20140401_180333.h5` (test data). If you have a file called `rawData_2019_01_01_myInterestingExperiment.avi` and all your raw data files start with `rawData_` then change the regular expression to `rawData_` when requested by the repository. See `setMovieInfo` module.
+- External software packages are downloaded into `_external_programs` folder and should be placed there if done manually.
 - See additional details in [Processing calcium imaging data](#processing-calcium-imaging-data).
-- When issues are encountered, first check the `*Common issues and fixes` Wiki page to see if a solution is there. Else, submit a new issue or email Biafra.
+- When issues are encountered, first check the `*Common issues and fixes` Wiki page to see if a solution is there. Else, submit a new issue or email Biafra (bahanonu [at] alum.mit.edu).
 
 ```MATLAB
 % Loads all directories
@@ -50,7 +52,7 @@ loadBatchFxns;
 % Loads the class into an object for use in this session
 obj = calciumImagingAnalysis;
 
-% Download and load dependent software packages.
+% Download and load dependent software packages into "_external_programs" folder.
 obj.loadDependencies;
 
 % [optional] Set the names calciumImagingAnalysis will look for in each folder

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ Clone the `calciumImagingAnalysis` repository or download the repository zip and
 - Point the MATLAB path to the `calciumImagingAnalysis` folder.
 - Run `loadBatchFxns.m` before using functions in the directory. This adds all directories and sub-directories to the MATLAB path.
 - Type `obj = calciumImagingAnalysis;` into MATLAB command window and follow instructions that appear after to add data and run analysis.
-- Run the `calciumImagingAnalysis` class method `loadDependencies` or type `obj.loadDependencies` after initializing a `calciumImagingAnalysis` object into the command window to add Fiji to path, download CNMF/CNMF-E repositories, download/setup CVX (for CNMF/CNMF-E), and download example data.
+- Run the `calciumImagingAnalysis` class method `loadDependencies` or type `obj.loadDependencies` after initializing a `calciumImagingAnalysis` object into the command window to download and add Fiji to path, download CNMF/CNMF-E repositories, download/setup CVX (for CNMF/CNMF-E), and download example data.
 
 Note
-- Place in folder where MATLAB will have write permissions, as it also creates a `private` subdirectory to store some user information.
+- Place `calciumImagingAnalysis` in a folder where MATLAB will have write permissions, as it also creates a `private` subdirectory to store some user information along with downloading required external software packages.
 - `file_exchange` folder contains File Exchange functions used by `calciumImagingAnalysis`. If does not exist, unzip `file_exchange.zip`.
 - In general, it is best to set the MATLAB startup directory to the `calciumImagingAnalysis` folder. This allows `java.opts` and `startup.m` to set the correct Java memory requirements and load the correct folders into the MATLAB path.
-- If `calciumImagingAnalysis` IS NOT the startup folder, place `java.opts` wherever the startup folder is so the correct Java memory requirements are set (important for using ImageJ/Miji in MATLAB).
+- If `calciumImagingAnalysis` IS NOT the startup folder, place `java.opts` wherever the MATLAB startup folder is so the correct Java memory requirements are set (important for using ImageJ/Miji in MATLAB).
 - If it appears an old `calciumImagingAnalysis` repository is loaded after pulling a new version, run `restoredefaultpath` and check that old `calciumImagingAnalysis` folders are not in the MATLAB path.
 - This version of `calciumImagingAnalysis` has been tested on Windows MATLAB `2015b`, `2017a`, and `2018b`. Moderate testing on Windows and OSX (10.10.5) `2017b` and `2018b`.
 
@@ -99,6 +99,8 @@ Note
 Run `example_downloadTestData.m` to download example one-photon miniature microscope test data to use for testing `calciumImagingAnalysis` preprocessing, cell extraction, and cell classification code. The data will be located at `data\2014_04_01_p203_m19_check01_raw` within the repository root directory.
 
 ### Dependencies
+
+By default external MATLAB-based software packages are stored in `_external_programs`.
 
 MATLAB dependencies (toolboxes used)
 
@@ -110,7 +112,7 @@ MATLAB dependencies (toolboxes used)
 
 ImageJ
 
-- Run `downloadMiji` from `downloads\downloadMiji.m` to download Fiji version appropriate to your platform.
+- Run `downloadMiji` from `downloads\downloadMiji.m` or `obj.loadDependencies` (when class initialized) to download Fiji version appropriate to your platform.
 - Else download Fiji (preferably __2015 December 22__ version): https://imagej.net/Fiji/Downloads.
 - Make sure have Miji in Fiji installation: http://bigwww.epfl.ch/sage/soft/mij/.
 - This is used as an alternative to the `calciumImagingAnalysis` `playMovie.m` function for viewing movies and is needed for some movie modification steps.
@@ -121,7 +123,7 @@ Saleae
 
 CNMF and CNMF-E
 
-- Download repositories by running `downloadCnmfGithubRepositories.m`.
+- Download repositories by running `downloadCnmfGithubRepositories.m` or `obj.loadDependencies` (when class initialized).
 - CNMF: https://github.com/flatironinstitute/CaImAn-MATLAB.
 - CNMF-E: https://github.com/bahanonu/CNMF_E
   - forked from https://github.com/zhoupc/CNMF_E to fix HDF5, movies with NaNs, and other related bugs.
@@ -132,6 +134,7 @@ CNMF and CNMF-E
 Below are a list of the top-level directories and what types of functions or files are within.
 
 - __@calciumImagingAnalysis__ - Contains `calciumImagingAnalysis` class and associated methods for calcium imaging analysis.
+- ___external_programs__ - External software packages (e.g. CNMF, CELLMax, and others) are stored here.
 - ___overloaded__ - Functions that overload core MATLAB functions to add functionality or fix display issues.
 - __behavior__ - Processing of behavior files (e.g. accelerometer data, Saleae files, etc.).
 - __classification__ - Classification of cells, e.g. manual classification of cell extraction outputs or cross-session grouping of cells.

--- a/_external_programs/README.md
+++ b/_external_programs/README.md
@@ -1,0 +1,15 @@
+# External software packages
+
+The folder `_external_programs` is for external software packages used by `calciumImagingAnalysis`.
+
+The following are likely to be found here:
+- GUI and display
+	- `Fiji`
+- Cell extraction
+	- `CELLMax`
+	- `CNMF`
+	- `CNMF-E`
+	- `CVX`
+	- `EXTRACT`
+- Motion correction
+	- `NoRMCorre`

--- a/classification/signalSorter.m
+++ b/classification/signalSorter.m
@@ -50,6 +50,7 @@ function [inputImages, inputSignals, choices] = signalSorter(inputImages,inputSi
 		% 2019.07.17 [00:29:16] - Added support for sparse input images (mainly ndSparse format). Reduced memory usage for cases when "options.preComputeImageCutMovies = 0" and "options.inputMovie" is a matrix (NOT a path to a movie) by skipping async/use of parallel workers.
 		% 2019.07.17 [20:37:09] - Added ability to change GUI font.
 		% 2019.07.23 [03:42:48] - Enclosed user selections inside try-catch to better handle invalid input robustly with checks added in the subfxn as needed.
+		% 2019.08.19 [18:07:27] - Added zoom and other functionality and a lock-check to prevent skipping forward to new cells based on pressing keyboard too long carrying over keypress into next source output, causing it to skip over outputs. Added progress bar for cell, non-cell, and unknown.
 
 	% TODO
 		% New GUI interface to allow users to scroll through video and see cell activity at that point
@@ -646,13 +647,24 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 		mkdir(tmpDir);
 	end
 
-	subplotTmp = @(x,y,z) subaxis(x,y,z, 'Spacing', 0.07, 'Padding', 0, 'MarginTop', 0.05,'MarginBottom', 0.05,'MarginLeft', 0.03,'MarginRight', 0.07);
+	subplotTmp = @(x,y,z) subaxis(x,y,z, 'Spacing', 0.07, 'Padding', 0, 'MarginTop', 0.05,'MarginBottom', 0.05,'MarginLeft', 0.03,'MarginRight', 0.07); % ,'Holdaxis',1
 	% subplotTmp = @(x,y,z) subplot(x,y,z);
 
 	% mainFig = openFigure(1,'full');
 	mainFig = figure(1);
 	% prevent matlab from giving command window focus
 	set(mainFig,'KeyPressFcn', '1;');
+
+	% % Prepare the figure
+	% hFig = figure;  % etc. - prepare the figure
+	% % Get the underlying Java reference
+	% warning off MATLAB:HandleGraphics:ObsoletedProperty:JavaFrame
+	% jFig = get(hFig, 'JavaFrame');
+	% jAxis = jFig.getAxisComponent;
+	% % Set the focus event callback
+	% set(jAxis.getComponent(0),'FocusLostCallback',{@subfxnLostFocusMainFig,hFig});
+	% set(jAxis,'FocusGainedCallback',{@myMatlabFunc,hFig});
+	% perhaps also set the FocusLostCallback here
 
 	% % location of each subplot
 	% if ~isempty(options.inputMovie)
@@ -833,6 +845,8 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 	objCutMovieAsyncF = cell([1 nSignalsHere]);
 	objCutImagesAsyncF = cell([1 nSignalsHere]);
 
+	% suptitle('Press Z to toggle zoom on all panels. Press L for keyboard shortcut legend.','plotregion',0.95,'titleypos',0.98)
+
 	% only exit if user clicks options that calls for saving the data
 	while saveData==0
 		if options.signalLoopTicTocCheck==1
@@ -873,7 +887,12 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 
 		if ~isempty(options.inputMovie)
 			% inputMoviePlotLoc2Handle = subplot(subplotY,subplotX,inputMoviePlotLoc2);
-			inputMoviePlotLoc2Handle = subplotTmp(subplotY,subplotX,inputMoviePlotLoc2);
+			if i==1
+				inputMoviePlotLoc2Handle = subplotTmp(subplotY,subplotX,inputMoviePlotLoc2);
+			else
+				% axes(inputMoviePlotLoc2Handle);
+				set(mainFig,'CurrentAxes',inputMoviePlotLoc2Handle);
+			end
 				% tic
 
 				if options.showImageCorrWithCharInputMovie==1
@@ -969,6 +988,9 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 								if i==1
 									imagesc(croppedPeakImages2,'AlphaData',imAlpha);
 									colormap(options.colormap);
+								else
+									% findobj(gca,'Type','image')
+									% pause
 								end
 								montageHandle = findobj(gca,'Type','image');
 								set(montageHandle,'Cdata',croppedPeakImages2,'AlphaData',imAlpha);
@@ -988,8 +1010,8 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 									axis equal tight;
 								end
 								% s2Pos = get(gca,'position');
-								s2Pos = plotboxpos(gca);
-								cbh = colorbar(gca,'Location','eastoutside','Position',[s2Pos(1)+s2Pos(3)+0.005 s2Pos(2) 0.01 s2Pos(4)],'FontSize',options.fontSize-2);
+								s2Pos = plotboxpos(inputMoviePlotLoc2Handle);
+								cbh = colorbar(inputMoviePlotLoc2Handle,'Location','eastoutside','Position',[s2Pos(1)+s2Pos(3)+0.005 s2Pos(2) 0.01 s2Pos(4)],'FontSize',options.fontSize-2);
 								ylabel(cbh,'Fluorescence (e.g. \DeltaF/F or \DeltaF/\sigma)','FontSize',options.fontSize-1);
 							end
 						catch err
@@ -1036,7 +1058,12 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 			% show the current image
 			% subplot(subplotY,subplotX,filterPlotLoc)
 			% subplot(subplotY,subplotX,inputMoviePlotLoc2)
-			subplotTmp(subplotY,subplotX,inputMoviePlotLoc2)
+			if i==1
+				inputMoviePlotLoc2Handle = subplotTmp(subplotY,subplotX,inputMoviePlotLoc2);
+			else
+				% axes(inputMoviePlotLoc2Handle);
+				set(mainFig,'CurrentAxes',inputMoviePlotLoc2Handle);
+			end
 				[thisImageCrop] = subfxnCropImages(thisImage);
 				imagesc(thisImageCrop);
 				% colormap gray
@@ -1073,7 +1100,12 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 			% badImages2 = normalizeVector(badImages,'normRange','zeroToOne');
 		% end
 		% subplot(subplotY,subplotX,objMapPlotLoc)
-		subplotTmp(subplotY,subplotX,objMapPlotLoc)
+		if i==1
+			objMapPlotLocHandle = subplotTmp(subplotY,subplotX,objMapPlotLoc);
+		else
+			set(mainFig,'CurrentAxes',objMapPlotLocHandle);
+		end
+
 			% currentImage = squeeze(inputImages(:,:,i));
 			currentImageThres = squeeze(inputImagesThres(:,:,i));
 			Comb(:,:,2) = ones(size(currentImageThres));
@@ -1184,7 +1216,12 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 			end
 			% title(strrep(options.inputStr,'_','\_'), 'HandleVisibility' , 'off' )
 		% subplot(subplotY,subplotX,objMapZoomPlotLoc)
-		subplotTmp(subplotY,subplotX,objMapZoomPlotLoc)
+		if i==1
+			objMapZoomPlotLocHandle = subplotTmp(subplotY,subplotX,objMapZoomPlotLoc);
+		else
+			% axes(objMapZoomPlotLocHandle);
+			set(mainFig,'CurrentAxes',objMapZoomPlotLocHandle);
+		end
 			% CombTmp2Zoom = CombTmp2;
 			% currentImage2(:,:,1) = currentImage;
 			% % currentImage2(:,:,2) = currentImage;
@@ -1254,7 +1291,7 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 				if options.axisEqual==1
 					axis equal tight;
 				end
-				title(['signal ' cellIDStr ' (' num2str(sum(valid==1)) ' good)'],'FontSize',options.fontSize)
+				title(['signal ' cellIDStr ' (' num2str(sum(valid==1)) ' good)' 10 'Legend: green(good), red(bad), blue(current)'],'FontSize',options.fontSize)
 				% 10 'Legend: green(good), red(bad), blue(current)'
 				box off;
 				axisH = gca;
@@ -1272,7 +1309,11 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 			% tic
 			% plot all signals and the average
 			% subplot(subplotY,subplotX,avgSpikeTracePlot);
-			subplotTmp(subplotY,subplotX,avgSpikeTracePlot);
+			if i==1
+				avgSpikeTracePlotHandle = subplotTmp(subplotY,subplotX,avgSpikeTracePlot);
+			else
+				set(mainFig,'CurrentAxes',avgSpikeTracePlotHandle);
+			end
 				% [slopeRatio] = plotPeakSignal(thisTrace,testpeaks,cellIDStr,instructionStr,minValTraces,maxValTraces,peakROI,peakOutputStat.avgSpikeTrace(i,:),peakOutputStat.slopeRatio(i),peakOutputStat.spikeCenterTrace{i},valid);
 				plotPeakSignal(thisTrace,testpeaks,cellIDStr,instructionStr,minValTraces,maxValTraces,peakROI,peakOutputStat.avgSpikeTrace(i,:),peakOutputStat.slopeRatio(i),peakOutputStat.spikeCenterTrace{i},valid);
 				axisH = gca;
@@ -1283,8 +1324,14 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 				% title(['signal ' cellIDStr]);
 			% plot the trace
 
-			% subplot(subplotY,subplotX,tracePlotLoc)
-			subplotTmp(subplotY,subplotX,tracePlotLoc)
+			% % subplot(subplotY,subplotX,tracePlotLoc)
+			% subplotTmp(subplotY,subplotX,tracePlotLoc)
+			if i==1
+				tracePlotLocHandle = subplotTmp(subplotY,subplotX,tracePlotLoc);
+			else
+				set(mainFig,'CurrentAxes',tracePlotLocHandle);
+			end
+
 				sigDig = 100;
 				thisStr = [...
 					'SNR = ' num2str(round(signalSnr(i)*sigDig)/sigDig)...
@@ -1326,14 +1373,22 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 			% toc
 		else
 			% subplot(subplotY,subplotX,avgSpikeTracePlot);
-			subplotTmp(subplotY,subplotX,avgSpikeTracePlot);
+			if i==1
+				avgSpikeTracePlotHandle = subplotTmp(subplotY,subplotX,avgSpikeTracePlot);
+			else
+				set(mainFig,'CurrentAxes',avgSpikeTracePlotHandle);
+			end
 				plot(peakROI,thisTrace(1:length(peakROI)));
 				xlabel('frames');
 				ylabel('\DeltaF/F');
 				ylim([minValTraces maxValTraces]);
 				title(['signal peaks ' cellIDStr],'FontSize',options.fontSize)
 			% subplot(subplotY,subplotX,tracePlotLoc)
-			subplotTmp(subplotY,subplotX,tracePlotLoc)
+			if i==1
+				tracePlotLocHandle = subplotTmp(subplotY,subplotX,tracePlotLoc);
+			else
+				set(mainFig,'CurrentAxes',tracePlotLocHandle);
+			end
 				plot(thisTrace, 'r');
 				xlabel('frames');
 				% ylabel('df/f');
@@ -1346,7 +1401,22 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 		if i==1
 			figure(mainFig);
 		end
-		set(findobj(gcf,'type','axes'),'hittest','off')
+		% Turn off ability for users to alter existing axes
+		% set(findobj(gcf,'type','axes'),'hittest','off')
+
+
+		set(mainFig,'CurrentAxes',avgSpikeTracePlotHandle);
+			% set(gca,'hittest','off')
+			box off;
+		set(mainFig,'CurrentAxes',tracePlotLocHandle);
+			% set(gca,'hittest','off')
+			box off;
+		set(mainFig,'CurrentAxes',objMapPlotLocHandle);
+			box off;
+		set(mainFig,'CurrentAxes',objMapZoomPlotLocHandle);
+			box off;
+		linkaxes([avgSpikeTracePlotHandle tracePlotLocHandle],'y');
+
 		validPrevious = valid(i);
 		warning('off','all')
 
@@ -1435,7 +1505,11 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 				objCutMovie(1,2,:) = options.movieMax;
 
 				% subplot(subplotY,subplotX,inputMoviePlotLoc)
-				subplotTmp(subplotY,subplotX,inputMoviePlotLoc)
+				if i==1
+					inputMoviePlotLocHandle = subplotTmp(subplotY,subplotX,inputMoviePlotLoc);
+				else
+					set(mainFig,'CurrentAxes',inputMoviePlotLocHandle);
+				end
 				% set title and turn off ability to change
 				if ~isempty(objCutMovie)
 					% imagesc(objCutMovie(:,:,1));
@@ -1490,6 +1564,7 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 				%     ' | S-ratio = ' num2str(round(peakOutputStat.slopeRatio(i)*sigDig)/sigDig)];
 
 				% title(tmpTitle,'HandleVisibility','off');
+
 				set(gca,'color',[0 0 0]);
 				loopImgHandle = imagesc(objCutMovie(:,:,frameNo),'AlphaData',imAlpha);
 				if options.axisEqual==1
@@ -1509,10 +1584,75 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 					caxis([-0.05 0.1]);
 				end
 
-				title(['Press Q to change movie contrast.' 10 'Press L for legend.'],'FontSize',options.fontSize)
+				% title(['Press Q to change movie contrast.' 10 'Press Z to toggle zoom on all panels.' 10 'Press L for keyboard shortcut legend.' 10 'signal ' cellIDStr ' (' num2str(sum(valid==1)) ' good)'],'FontSize',options.fontSize)
+				title(['Press Q to change movie contrast.' 10 'Press Z to toggle zoom on all panels.' 10 'Press L for keyboard shortcut legend.'],'FontSize',options.fontSize)
 
+				% pause
+				validData = cat(3,double(valid(:)'==0|valid(:)'>1),double(valid(:)'==1|valid(:)'>1),double(valid(:)'>1))/2;
+				validData(:,valid==0,1) = 1;
+				validData(:,valid==1,2) = 1;
+				% loopImgHandle
+				if i==1
+					% suptitle(' ','plotregion',0.95,'titleypos',0.98)
+					% suptitle('Press Z to toggle zoom on all panels. Press L for keyboard shortcut legend.','plotregion',0.95,'titleypos',0.98)
+					s3Pos = plotboxpos(gca);
+					% axValid = axes('Position',[s3Pos(1) s3Pos(2)-0.03 s3Pos(3) 0.02],'XTick',[],'YTick',[]);
+
+					axValid = axes('Position',[s3Pos(1) 0.98 s3Pos(3) 0.02],'XTick',[],'YTick',[]);
+					validImgHandle = imagesc(axValid,validData);
+					% box off;
+					set(axValid,'XTick',[],'YTick',[])
+					% axis off;
+					xlabel(['Cell (green), non-cell (red), unknown (gray) | ' 'signal ' cellIDStr ' (' num2str(sum(valid==1)) ' good)'],'FontSize',options.fontSize-2)
+					% loopImgHandle
+					% pause
+				else
+					% axValid
+					thisHandle = findobj(axValid,'Type','image');
+					set(thisHandle,'CData',validData);
+					set(mainFig,'CurrentAxes',axValid);
+					xlabel(['Cell (green), non-cell (red), unknown (gray) | ' 'signal ' cellIDStr ' (' num2str(sum(valid==1)) ' good)'],'FontSize',options.fontSize-2)
+				end
+
+				validSorted = sort(valid);
+				validData = cat(3,double(validSorted(:)'==0|validSorted(:)'>1),double(validSorted(:)'==1|validSorted(:)'>1),double(validSorted(:)'>1))/2;
+				validData(:,validSorted==0,1) = 1;
+				validData(:,validSorted==1,2) = 1;
+				if i==1
+					set(mainFig,'CurrentAxes',inputMoviePlotLoc2Handle);
+					s3Pos = plotboxpos(gca);
+					axValidAll = axes('Position',[s3Pos(1) 0.98 s3Pos(3) 0.02],'XTick',[],'YTick',[]);
+					validImgHandle = imagesc(axValidAll,validData);
+					set(axValidAll,'XTick',[],'YTick',[])
+					xlabel(['Percent: cell (green), non-cell (red), unknown (gray).'],'FontSize',options.fontSize-2)
+				else
+					thisHandle = findobj(axValidAll,'Type','image');
+					set(thisHandle,'CData',validData);
+					% set(mainFig,'CurrentAxes',axValid);
+					% xlabel(['Cell (green), non-cell (red), unknown (gray)'],'FontSize',options.fontSize-2)
+				end
+
+				set(mainFig,'CurrentAxes',inputMoviePlotLocHandle);
+				% subplotTmp(subplotY,subplotX,inputMoviePlotLoc)
+
+				% h = zoom;
+				% ax2 = subplotTmp(subplotY,subplotX,objMapPlotLoc);
+				% setAllowAxesZoom(h,ax2,true);
+				% zoom on
+				% get(gcf,'CurrentCharacter')
+				frameNoTotal = 0; % use this to lock
+
+				% set(mainFig,'KeyPressFcn', '1;');
 				while strcmp(keyIn,'3')
-					keyIn = get(gcf,'CurrentCharacter');
+					% figure(mainFig)
+					frameNoTotal = frameNoTotal+1;
+					% disp(frameNoTotal)
+					if frameNoTotal>3
+						keyIn = get(gcf,'CurrentCharacter');
+					else
+						set(gcf,'currentch','3');
+					end
+					% disp(double(keyIn))
 					if ~isempty(objCutMovie)
 						% Use Cdata update instead of imagesc to improve drawnow speed, esp. on Matlab 2018b.
 						set(loopImgHandle,'Cdata',squeeze(objCutMovie(:,:,frameNo)));
@@ -1654,6 +1794,16 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 				disp(getReport(err,'extended','hyperlinks','on'));
 				disp(repmat('@',1,7))
 			end
+		% 'P' display neighboring cells
+		elseif isequal(reply, 112)
+			disp('Paused, press key to resume.')
+			pause;
+		% 'Z' display neighboring cells
+		elseif isequal(reply, 122)
+			% disp('Paused, press key to resume.')
+			% pause;
+			% zoom on;
+			zoom;
 		% 'T' display neighboring cells
 		elseif isequal(reply, 116)
 			overlapDistance = inputdlg('Enter distance to look for neighbors','',[1 50],{'10'});
@@ -1864,6 +2014,10 @@ function [valid] = chooseSignals(options,signalList, inputImages,inputSignals,ob
 	end
 end
 
+function subfxnLostFocusMainFig(jAxis, jEventData, hFig)
+   figure(hFig);
+end
+
 function instructionStr = subfxnCreateLegend()
 	% legendFig = figure(343);
 	% clf
@@ -1890,6 +2044,8 @@ function instructionStr = subfxnCreateLegend()
 	'e          | change fps of transient movies',sepStrNum,...
 	'd          | change colormap',sepStrNum,...
 	'l          | create new legend',sepStrNum,...
+	'p          | pause GUI, goto command window',sepStrNum,...
+	'z          | toggle zoom',sepStrNum,...
 	'a          | change GUI font',sepStrNum,sepStrNum,...
 	'===Cell map legend===',sepStrNum,...
 	'green = good',sepStrNum,...
@@ -2392,6 +2548,9 @@ function [valid, directionOfNextChoice, saveData, i] = respondToUserInput(reply,
 	else
 		% forward=1;
 		% valid(i) = 1;
+	end
+	if directionOfNextChoice~=0
+		zoom off;
 	end
 end
 function [outputImage] = subfxnCropImages(inputImages)

--- a/download/downloadCnmfGithubRepositories.m
+++ b/download/downloadCnmfGithubRepositories.m
@@ -16,7 +16,7 @@ function [success] = downloadCnmfGithubRepositories(varargin)
 	%========================
 
 	try
-		signalExtractionDir = 'signal_extraction';
+		signalExtractionDir = '_external_programs';
 
 		gitNameDisp = {'CNMF-E','CNMF | CaImAn','cvx-rd'};
 		gitRepos = {'https://github.com/bahanonu/CNMF_E/archive/master.zip','https://github.com/flatironinstitute/CaImAn-MATLAB/archive/master.zip','http://web.cvxr.com/cvx/cvx-rd.zip'};
@@ -58,8 +58,8 @@ function [success] = downloadCnmfGithubRepositories(varargin)
 
 		% if cvx is not in the path, ask user for file
 		if isempty(which('cvx_begin'))
-			display('Dialog box: Select cvx_setup.m (likely `calciumImagingAnalysis/signal_extraction/cvx_rd`')
-			[filePath,folderPath,~] = uigetfile(['*.*'],'Select cvx_setup.m (likely `calciumImagingAnalysis/signal_extraction/cvx_rd`');
+			display('Dialog box: Select cvx_setup.m (likely `calciumImagingAnalysis/_external_programs/cvx_rd`')
+			[filePath,folderPath,~] = uigetfile(['*.*'],'Select cvx_setup.m (likely `calciumImagingAnalysis/_external_programs/cvx_rd`');
 			run([folderPath filesep filePath]);
 		end
 

--- a/download/downloadCnmfGithubRepositories.m
+++ b/download/downloadCnmfGithubRepositories.m
@@ -4,9 +4,10 @@ function [success] = downloadCnmfGithubRepositories(varargin)
 	% started: 2019.01.14 [10:23:05]
 
 	%========================
+	options.defaultExternalProgramDir = ['_external_programs'];
 	% options.downloadPreprocessed = 0;
 	% get options
-	% options = getOptions(options,varargin);
+	options = getOptions(options,varargin);
 	% display(options)
 	% unpack options into current workspace
 	% fn=fieldnames(options);
@@ -16,7 +17,7 @@ function [success] = downloadCnmfGithubRepositories(varargin)
 	%========================
 
 	try
-		signalExtractionDir = '_external_programs';
+		signalExtractionDir = options.defaultExternalProgramDir;
 
 		gitNameDisp = {'CNMF-E','CNMF | CaImAn','cvx-rd'};
 		gitRepos = {'https://github.com/bahanonu/CNMF_E/archive/master.zip','https://github.com/flatironinstitute/CaImAn-MATLAB/archive/master.zip','http://web.cvxr.com/cvx/cvx-rd.zip'};
@@ -58,9 +59,16 @@ function [success] = downloadCnmfGithubRepositories(varargin)
 
 		% if cvx is not in the path, ask user for file
 		if isempty(which('cvx_begin'))
-			display('Dialog box: Select cvx_setup.m (likely `calciumImagingAnalysis/_external_programs/cvx_rd`')
-			[filePath,folderPath,~] = uigetfile(['*.*'],'Select cvx_setup.m (likely `calciumImagingAnalysis/_external_programs/cvx_rd`');
-			run([folderPath filesep filePath]);
+			checkCVXpath = [options.defaultExternalProgramDir filesep 'cvx_rd'];
+			if exist(checkCVXpath,'dir')==7
+				mfileToRun = [options.defaultExternalProgramDir filesep 'cvx_rd' filesep 'cvx_setup.m'];
+				fprintf('AUTOMATICALLY running cvx_setup.m: %s\n',mfileToRun)
+			else
+				display('Dialog box: Select cvx_setup.m (likely `calciumImagingAnalysis/_external_programs/cvx_rd`')
+				[filePath,folderPath,~] = uigetfile(['*.*'],'Select cvx_setup.m (likely `calciumImagingAnalysis/_external_programs/cvx_rd`');
+				mfileToRun = [folderPath filesep filePath];
+			end
+			run(mfileToRun);
 		end
 
 		success = 1;

--- a/download/downloadGithubRepositories.m
+++ b/download/downloadGithubRepositories.m
@@ -1,0 +1,75 @@
+function [success] = downloadGithubRepositories(varargin)
+	% Biafra Ahanonu
+	% Downloads Github repositories repositories.
+	% started: 2019.01.14 [10:23:05]
+
+	%========================
+	% options.downloadPreprocessed = 0;
+	% get options
+	% options = getOptions(options,varargin);
+	% display(options)
+	% unpack options into current workspace
+	% fn=fieldnames(options);
+	% for i=1:length(fn)
+	% 	eval([fn{i} '=options.' fn{i} ';']);
+	% end
+	%========================
+
+	try
+		signalExtractionDir = '_external_programs';
+
+		gitNameDisp = {'NoRMCorre'};
+		gitRepos = {'https://github.com/flatironinstitute/NoRMCorre/archive/master.zip'};
+		outputDir = {'normcorre'};
+		gitName = {'NoRMCorre-master'};
+		nRepos = length(outputDir);
+
+		for gitNo = 1:nRepos
+			display(repmat('=',1,7))
+			fprintf('%s\n',gitNameDisp{gitNo});
+			if exist([signalExtractionDir filesep outputDir{gitNo}],'dir')
+				fprintf('Already extracted %s\n',[signalExtractionDir filesep outputDir{gitNo}]);
+				continue;
+			end
+			% Make directory
+			rawSavePathDownload = [signalExtractionDir];
+			if ~exist(rawSavePathDownload,'dir');mkdir(rawSavePathDownload);fprintf('Made folder: %s',rawSavePathDownload);end
+
+			% Download git repo zip
+			rawSavePathDownload = [rawSavePathDownload filesep outputDir{gitNo} '.zip'];
+			if exist(rawSavePathDownload,'file')~=2
+				fprintf('Downloading %s file to %s\n',gitRepos{gitNo},rawSavePathDownload)
+				websave(rawSavePathDownload,gitRepos{gitNo});
+			else
+				fprintf('Already downloaded %s\n',rawSavePathDownload)
+			end
+
+			% Unzip the repo file
+			fprintf('Unzipping file %s\n',rawSavePathDownload)
+			filenames = unzip(rawSavePathDownload,signalExtractionDir);
+			% cellfun(@disp,filenames,'UniformOutput',false)
+
+			% Rename to proper folder for calciumImagingAnalysis
+			fprintf('Renaming %s to %s \n',[signalExtractionDir filesep gitName{gitNo}],[signalExtractionDir filesep outputDir{gitNo}])
+			movefile([signalExtractionDir filesep gitName{gitNo}],[signalExtractionDir filesep outputDir{gitNo}]);
+
+			% fprintf('\n\n')
+		end
+
+		success = 1;
+	catch err
+		success = 0;
+		disp('Check internet connection or download and unzip files manually, see:')
+		try
+			cellfun(@disp,gitRepos,'UniformOutput',false)
+		catch err2
+			display(repmat('@',1,7))
+			disp(getReport(err2,'extended','hyperlinks','on'));
+			display(repmat('@',1,7))
+		end
+		fprintf('\n\n')
+		display(repmat('@',1,7))
+		disp(getReport(err,'extended','hyperlinks','on'));
+		display(repmat('@',1,7))
+	end
+end

--- a/download/downloadMiji.m
+++ b/download/downloadMiji.m
@@ -92,7 +92,7 @@ function [success] = downloadMiji(varargin)
 				modelAddOutsideDependencies('miji');
 			elseif exist(unzipPath,'dir')~=7
 				% Unzip the repo file
-				if ~exist(unzipPath,'dir');mkdir(unzipPath);fprintf('Made folder: %s',unzipPath);end
+				if ~exist(unzipPath,'dir');mkdir(unzipPath);fprintf('Made folder: %s\n',unzipPath);end
 				fprintf('Unzipping file %s to %s\n',rawSavePathDownload,unzipPath)
 				% unzipPath = [signalExtractionDir filesep outputDir{gitNo}];
 				filenames = unzip(rawSavePathDownload,unzipPath);
@@ -106,7 +106,12 @@ function [success] = downloadMiji(varargin)
 			% movefile([signalExtractionDir filesep gitName{gitNo}],[signalExtractionDir filesep outputDir{gitNo}]);
 		end
 
-		modelAddOutsideDependencies('miji');
+		if exist('unzipPath','var')&&exist(unzipPath,'dir')==7
+			defaultExternalProgramDir = unzipPath;
+		else
+			defaultExternalProgramDir = options.defaultDir;
+		end
+		modelAddOutsideDependencies('miji','defaultExternalProgramDir',defaultExternalProgramDir);
 
 		success = 1;
 	catch err

--- a/download/downloadMiji.m
+++ b/download/downloadMiji.m
@@ -4,7 +4,8 @@ function [success] = downloadMiji(varargin)
 	% started: 2019.07.30 [09:58:04]
 
 	%========================
-	options.defaultDir = ['private' filesep 'programs'];
+	% options.defaultDir = ['private' filesep 'programs'];
+	options.defaultDir = ['_external_programs'];
 	% get options
 	options = getOptions(options,varargin);
 	% display(options)

--- a/hdf5/createHdf5File.m
+++ b/hdf5/createHdf5File.m
@@ -9,6 +9,7 @@ function createHdf5File(filename, datasetName, inputData, varargin)
 
 	% changelog
 		% 2019.03.25 [17:17:49] - Add support for custom user HDF5 chunking as opposed to previous automatic chunking
+		% 2019.08.20 [11:38:54] - Added additional support for more data types.
 	% TODO
 		%
 	%========================
@@ -66,7 +67,15 @@ function createHdf5File(filename, datasetName, inputData, varargin)
 			dsetType_id = H5T.copy('H5T_NATIVE_DOUBLE');
 		case 'uint16'
 			dsetType_id = H5T.copy('H5T_NATIVE_UINT16');
+		case 'int16'
+			dsetType_id = H5T.copy('H5T_NATIVE_INT16');
+		case 'uint8'
+			dsetType_id = H5T.copy('H5T_NATIVE_UINT8');
+		case 'int8'
+			dsetType_id = H5T.copy('H5T_NATIVE_INT8');
 		otherwise
+			disp(['Data type ' inputClass ' not supported.'])
+			return;
 			% body
 	end
 

--- a/image/findCentroid.m
+++ b/image/findCentroid.m
@@ -64,6 +64,9 @@ function [xCoords yCoords allCoords] = findCentroid(inputMatrix,varargin)
 	options_roundCentroidPosition = options.roundCentroidPosition;
 	options_waitbarOn = options.waitbarOn;
 
+	% xCoords = NaN([1 nImages]);
+	% yCoords = NaN([1 nImages]);
+
 	parfor imageNum=1:nImages
 		% threshold image
 		thisImage = squeeze(inputMatrixThreshold(:,:,imageNum));

--- a/io/modelAddOutsideDependencies.m
+++ b/io/modelAddOutsideDependencies.m
@@ -14,6 +14,7 @@ function [success] = modelAddOutsideDependencies(dependencyName,varargin)
 
 	%========================
 	options.exampleOption = '';
+	options.defaultExternalProgramDir = ['_external_programs'];
 	% get options
 	options = getOptions(options,varargin);
 	% display(options)
@@ -35,8 +36,22 @@ function [success] = modelAddOutsideDependencies(dependencyName,varargin)
 					% pathToMiji = inputdlg('Enter path to Miji.m in Fiji (e.g. \Fiji.app\scripts):',...
 					%              'Miji path', [1 100]);
 					% pathToMiji = pathToMiji{1};
-					display('Dialog box: Enter path to Miji.m in Fiji (likely in "scripts" folder, e.g. \Fiji.app\scripts)')
-					pathToMiji = uigetdir('\.','Enter path to Miji.m in Fiji (likely in "scripts" folder, e.g. \Fiji.app\scripts)');
+					% display('Dialog box: Enter path to Miji.m in Fiji (likely in "scripts" folder, e.g. \Fiji.app\scripts)')
+					checkMijiPath = [options.defaultExternalProgramDir filesep 'Fiji.app' filesep 'scripts'];
+					if exist(checkMijiPath,'dir')==7
+						fprintf('AUTOMATICALLY adding Miji path: %s\n',checkMijiPath);
+						pathToMiji = checkMijiPath;
+					else
+						if exist(options.defaultExternalProgramDir,'dir')==7
+							loadPathHere = options.defaultExternalProgramDir;
+							loadStr = ['Enter path to Miji.m in Fiji (likely in "scripts" folder, e.g. calciumImagingAnalysis\' options.defaultExternalProgramDir '\Fiji.app\scripts)'];
+						else
+							loadPathHere = '\.';
+							loadStr = ['Enter path to Miji.m in Fiji (likely in "scripts" folder, e.g. \Fiji.app\scripts)'];
+						end
+						disp(['Dialog box: ' loadStr])
+						pathToMiji = uigetdir(loadPathHere,loadStr);
+					end
 					if ischar(pathToMiji)
 						privateLoadBatchFxnsPath = 'private\settings\privateLoadBatchFxns.m';
 						if exist(privateLoadBatchFxnsPath,'file')~=0

--- a/loadBatchFxns.m
+++ b/loadBatchFxns.m
@@ -9,6 +9,8 @@ function loadBatchFxns()
 
 	% changelog
 		% 2019.07.25 [09:08:59] - Changed so that it adds folders to path from the directory where loadBatchFxns.m is located.
+		% 2019.08.20 [09:18:01] - Improve speed by checking for folders already in MATLAB path.
+		% 2019.08.25 [15:29:36] - Simplified Miji loading
 	% TODO
 		%
 
@@ -19,7 +21,6 @@ function loadBatchFxns()
 	functionLocation = dbstack('-completenames');
 	functionLocation = functionLocation(1).file;
 	[functionDir,~,~] = fileparts(functionLocation);
-	fprintf('Adding all non-private folders under: %s\n',functionDir);
 	pathList = genpath(functionDir);
 	% pathList = genpath(pwd);
 	pathListArray = strsplit(pathList,pathsep);
@@ -38,8 +39,18 @@ function loadBatchFxns()
 		pathListArray = pathListArray(~matchIdx);
 	end
 
-	pathList = strjoin(pathListArray,pathsep);
-	addpath(pathList);
+	% Remove paths that are already in MATLAB path to save time
+	pathFilter = cellfun(@isempty,pathListArray);
+	pathListArray = pathListArray(~pathFilter);
+	pathFilter = ismember(pathListArray,strsplit(path,pathsep));
+	pathListArray = pathListArray(~pathFilter);
+	if isempty(pathListArray)
+		fprintf('MATALB path already has all needed non-private folders under: %s\n',functionDir);
+	else
+		fprintf('Adding all non-private folders under: %s\n',functionDir);
+		pathList = strjoin(pathListArray,pathsep);
+		addpath(pathList);
+	end
 
 	% Automatically add Inscopix
 	if ismac
@@ -51,28 +62,45 @@ function loadBatchFxns()
 	else
 		disp('Platform not supported')
 	end
-	if ~isempty(baseInscopixPath)&&exist(baseInscopixPath,'dir')==7
-		addpath(baseInscopixPath);
-		if exist('isx.Movie','class')==8
-			fprintf('Inscopix Data Processing software added: %s\n',baseInscopixPath)
+
+	pathFilter = ismember(baseInscopixPath,strsplit(path,pathsep));
+	if pathFilter==0
+		if ~isempty(baseInscopixPath)&&exist(baseInscopixPath,'dir')==7
+			addpath(baseInscopixPath);
+
+			if exist('isx.Movie','class')==8
+				fprintf('Inscopix Data Processing software added: %s\n',baseInscopixPath)
+			else
+				disp('Check Inscopix Data Processing software install!')
+			end
 		else
-			disp('Check Inscopix Data Processing software install!')
 		end
 	else
+		fprintf('Inscopix Data Processing software already in path: %s\n',baseInscopixPath)
 	end
 
 	% add path for Miji, change as needed
-	pathtoMiji = '\Fiji.app\scripts\';
-	if exist(pathtoMiji,'dir')==7
-		onPath = subfxnCheckPath(pathtoMiji);
+	loadLocalFunctions = ['private' filesep 'settings' filesep 'privateLoadBatchFxns.m'];
+	if exist(loadLocalFunctions,'file')~=0
+		run(loadLocalFunctions);
+	else
+		pathtoMiji = ['_external_programs' filesep 'fiji-win64-20151222' filesep 'Fiji.app' filesep 'scripts\'];
+		% create privateLoadBatchFxns.m
+	end
+	onPath = subfxnCheckPath(pathtoMiji);
+	if exist(pathtoMiji,'dir')==7&&onPath==0
 		if onPath==1
 			fprintf('Miji already in PATH: %s.\n',pathtoMiji)
 		else
 			addpath(pathtoMiji);
-			fprintf('Added default Miji to path: %s.\n',pathtoMiji)
+			fprintf('Added private Miji to path: %s.\n',pathtoMiji)
 		end
 		try
-			currP=pwd;Miji;cd(currP);MIJ.exit;
+			currP=pwd;
+			Miji;
+			% MIJ.start;
+			cd(currP);
+			MIJ.exit;
 		catch err
 			disp(repmat('@',1,7))
 			disp(getReport(err,'extended','hyperlinks','on'));
@@ -80,54 +108,25 @@ function loadBatchFxns()
 			manageMiji('startStop','start');
 			manageMiji('startStop','exit');
 		end
-		% % Get Miji properly loaded in the path if not already
-		% if exist('MIJ','class')==0
+		% % Get Miji properly loaded in the path
+		% if exist('Miji.m')==2&&exist('MIJ','class')==0
 		% 	resetMiji;
+		% else
 		% end
+	elseif onPath==1
+		fprintf('Miji already in MATLAB path: %s\n',pathtoMiji);
 	else
-		clear pathtoMiji;
-	end
-
-	loadLocalFunctions = ['private' filesep 'settings' filesep 'privateLoadBatchFxns.m'];
-	if exist(loadLocalFunctions,'file')~=0
-		run(loadLocalFunctions);
-		onPath = subfxnCheckPath(pathtoMiji);
-		if exist(pathtoMiji,'dir')==7
-			if onPath==1
-				fprintf('Miji already in PATH: %s.\n',pathtoMiji)
-			else
-				addpath(pathtoMiji);
-				fprintf('Added private Miji to path: %s.\n',pathtoMiji)
-			end
-			try
-				currP=pwd;Miji;cd(currP);MIJ.exit;
-			catch err
-				disp(repmat('@',1,7))
-				disp(getReport(err,'extended','hyperlinks','on'));
-				disp(repmat('@',1,7))
-				manageMiji('startStop','start');
-				manageMiji('startStop','exit');
-			end
-			% % Get Miji properly loaded in the path
-			% if exist('Miji.m')==2&&exist('MIJ','class')==0
-			% 	resetMiji;
-			% else
-			% end
-		else
-			fprintf('No folder at specified path, retry! %s.\n',pathtoMiji)
-		end
-	else
-		% create privateLoadBatchFxns.m
+		fprintf('No folder at specified path, retry! %s.\n',pathtoMiji)
 	end
 	% cnmfVersionDirLoad('none');
 end
 function onPath = subfxnCheckPath(thisRootPath)
 	pathCell = regexp(path, pathsep, 'split');
-			if verLessThan('matlab','9.0')
-				matchIdx = ~cellfun(@isempty,regexpi(pathCell,thisRootPath));
-				% pathListArray = pathListArray(pathFilter&pathFilter1&pathFilter2);
-			else
-				matchIdx = contains(pathCell,thisRootPath);
-			end
+	if verLessThan('matlab','9.0')
+		matchIdx = ~cellfun(@isempty,regexpi(pathCell,thisRootPath));
+		% pathListArray = pathListArray(pathFilter&pathFilter1&pathFilter2);
+	else
+		matchIdx = contains(pathCell,thisRootPath);
+	end
 	onPath = any(matchIdx);
 end

--- a/loadBatchFxns.m
+++ b/loadBatchFxns.m
@@ -95,19 +95,7 @@ function loadBatchFxns()
 			addpath(pathtoMiji);
 			fprintf('Added private Miji to path: %s.\n',pathtoMiji)
 		end
-		try
-			currP=pwd;
-			Miji;
-			% MIJ.start;
-			cd(currP);
-			MIJ.exit;
-		catch err
-			disp(repmat('@',1,7))
-			disp(getReport(err,'extended','hyperlinks','on'));
-			disp(repmat('@',1,7))
-			manageMiji('startStop','start');
-			manageMiji('startStop','exit');
-		end
+		openMijiCheck();
 		% % Get Miji properly loaded in the path
 		% if exist('Miji.m')==2&&exist('MIJ','class')==0
 		% 	resetMiji;
@@ -115,10 +103,26 @@ function loadBatchFxns()
 		% end
 	elseif onPath==1
 		fprintf('Miji already in MATLAB path: %s\n',pathtoMiji);
+		openMijiCheck()
 	else
 		fprintf('No folder at specified path, retry! %s.\n',pathtoMiji)
 	end
 	% cnmfVersionDirLoad('none');
+end
+function openMijiCheck()
+	try
+		currP=pwd;
+		Miji;
+		% MIJ.start;
+		cd(currP);
+		MIJ.exit;
+	catch err
+		disp(repmat('@',1,7))
+		disp(getReport(err,'extended','hyperlinks','on'));
+		disp(repmat('@',1,7))
+		manageMiji('startStop','start');
+		manageMiji('startStop','exit');
+	end
 end
 function onPath = subfxnCheckPath(thisRootPath)
 	pathCell = regexp(path, pathsep, 'split');

--- a/motion_correction/turboregMovie.m
+++ b/motion_correction/turboregMovie.m
@@ -106,7 +106,7 @@ function [inputMovie, ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	options.meanSubtract = 0;
 	% subtract the mean from each frame?
 	options.meanSubtractNormalize = 0;
-	% highpass or divideByLowpass
+	% String: imagejFFT,matlabDisk,divideByLowpass,highpass,bandpass
 	options.normalizeType = 'divideByLowpass';
 	% name in HDF5 file where data is stored
 	options.inputDatasetName = '/1';
@@ -135,6 +135,9 @@ function [inputMovie, ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	options.showFigs = 1;
 	% cmd line waitbar on?
 	options.waitbarOn = 1;
+
+	% Binary: 1 = return the movie after normalizing, mean subtract, etc.
+	options.returnNormalizedMovie = 0;
 
 	% get options
 	options = getOptions(options,varargin);
@@ -218,7 +221,7 @@ function [inputMovie, ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	% ========================
 	% register movie and return without using the rest of the function
 	if ~isempty(options.precomputedRegistrationCooordsFullMovie)
-		disp('Input pre-computed registration coordinates...')
+		disp('Input pre-computed registration coordinates for full movie...')
 		ResultsOut = options.precomputedRegistrationCooordsFullMovie;
 		% ResultsOutOriginal = ResultsOut;
 		% for resultNo=1:size(inputMovie,3)
@@ -250,6 +253,11 @@ function [inputMovie, ResultsOutOriginal] = turboregMovie(inputMovie, varargin)
 	% if input crop coordinates are given, save a copy of the uncropped movie and crop the current movie
 	inputMovieCropped = [];
 	cropAndNormalizeInputMovie();
+
+	if options.returnNormalizedMovie==1
+		inputMovie = inputMovieCropped;
+		return;
+	end
 	% ========================
 	manageParallelWorkers('parallel',options.parallel);
 	%========================

--- a/movie_processing/normalizeMovie.m
+++ b/movie_processing/normalizeMovie.m
@@ -89,7 +89,7 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 	if ~verLessThan('matlab', '9.2')
 		D = parallel.pool.DataQueue;
 		afterEach(D, @nUpdateParforProgress);
-		p = 1;
+		p = 0;
 		N = size(inputMovie,3);
 		nInterval = round(N/20);%100
 		options_waitbarOn = options.waitbarOn;
@@ -161,7 +161,7 @@ function [inputMovie] = normalizeMovie(inputMovie, varargin)
 	function nUpdateParforProgress(~)
 		if ~verLessThan('matlab', '9.2')
 			p = p + 1;
-			if (mod(p,nInterval)==0||p==2||p==nFrames)&&options_waitbarOn==1
+			if (mod(p,nInterval)==0||p==1||p==nFrames)&&options_waitbarOn==1
 				if p==nFrames
 					fprintf('%d\n',round(p/nFrames*100))
 				else

--- a/signal_extraction/cnmfVersionDirLoad.m
+++ b/signal_extraction/cnmfVersionDirLoad.m
@@ -15,7 +15,7 @@ function [success] = cnmfVersionDirLoad(cnmfVersion,varargin)
 
 	%========================
 	% Relative path assumed for batch_processing package
-	options.signalExtractionRootPath = 'signal_extraction';
+	options.signalExtractionRootPath = '_external_programs';
 	% Binary: 1 = display paths to be added or removed
 	options.displayOutput = 1;
 	% get options

--- a/signal_extraction/normalizeSignalExtractionActivityTraces.m
+++ b/signal_extraction/normalizeSignalExtractionActivityTraces.m
@@ -1,0 +1,36 @@
+function inputSignals = normalizeSignalExtractionActivityTraces(inputSignals,inputImages)
+	% Normalizes cell activity traces by the max value in the associated image, normally to produce dF/F equivalent activity traces
+	% started: 2019.08.25 [18:19:34]
+	% Biafra Ahanonu
+	% Branched from normalizeCELLMaxTraces (Lacey Kitch and Biafra Ahanonu)
+	% inputs
+		% inputImages - [N x y] matrix where N = number of images, x/y are dimensions. Use permute(inputImages,[3 1 2]) if you use [x y N] for matrix indexing.
+		% inputSignals - [N time] matrix where N = number of signals (traces) and time = frames.
+	% outputs
+		% inputSignals - [N time] matrix where N = number of signals (traces) and time = frames. These are the modified signals
+
+	% changelog
+		%
+	% TODO
+		%
+
+	%========================
+	% options.exampleOption = '';
+	% get options
+	% options = getOptions(options,varargin);
+	% display(options)
+	% unpack options into current workspace
+	% fn=fieldnames(options);
+	% for i=1:length(fn)
+	% 	eval([fn{i} '=options.' fn{i} ';']);
+	% end
+	%========================
+
+	nCells = size(inputSignals,1);
+	disp('Normalizing traces by cell image values.')
+	for cellNo = 1:nCells
+	    thisImage = inputImages(:,:,cellNo);
+	    normFactor = max(thisImage(:));
+	    inputSignals(cellNo,:) = inputSignals(cellNo,:)*normFactor;
+	end
+end

--- a/signal_processing/computeSignalSnr.m
+++ b/signal_processing/computeSignalSnr.m
@@ -80,9 +80,7 @@ function [inputSnr, inputMse, inputSnrSignal, inputSnrNoise, outputSignal, outpu
 			end
 		end
 
-		if options.displayOutput==1
-			disp(['SNR type: ' options.SNRtype])
-		end
+
 		% to later calculate the signal idx
 		% outerFun = @(x,y) x+y;
 		nSignals = size(inputSignals,1);
@@ -95,6 +93,11 @@ function [inputSnr, inputMse, inputSnrSignal, inputSnrNoise, outputSignal, outpu
 			testpeaksArray = options.testpeaksArray;
 			options.testpeaksArray = [];
 		end
+
+		if options.displayOutput==1
+			disp(['SNR type: ' options.SNRtype])
+		end
+
 		if isempty(options.testpeaksArrayAlt)
 			testpeaksArrayAlt = [];
 		else


### PR DESCRIPTION
- `signalSorter` - Allow zoom and other functionality and a lock-check to prevent skipping forward to new cells based on pressing keyboard too long carrying over keypress into next source output, causing it to skip over outputs.
- `signalSorter` - changed how axes are called to allow more flexibility with other UI elements.
- `signalSorter` - Added progress bar for cell, non-cell, and unknown.
- `viewAcceptedRejectedCellExtraction` - additional options to improve display.
- Change additional functions that download and load external software packages to use '_external_programs' folder.
- Added a general github repo downloader, at the moment supports NoRMCorre, additional support coming.